### PR TITLE
LFX Mentorship Task1

### DIFF
--- a/LFX Mentorship Task1
+++ b/LFX Mentorship Task1
@@ -1,2 +1,0 @@
-a public link of the dataset benchmarking website : jaleWang.github.io
-the corresponding dataset introduction :Cityscapes is comprised of a large, diverse set of stereo video sequences recorded in streets from 50 different cities. 5000 of these images have high-quality pixel-level annotations; 20 000 additional images have coarse annotations to enable methods that leverage large volumes of weakly-labeled data。For more information, please refer to the website.

--- a/LFX Mentorship Task1
+++ b/LFX Mentorship Task1
@@ -1,0 +1,2 @@
+a public link of the dataset benchmarking website : jaleWang.github.io
+the corresponding dataset introduction :Cityscapes is comprised of a large, diverse set of stereo video sequences recorded in streets from 50 different cities. 5000 of these images have high-quality pixel-level annotations; 20 000 additional images have coarse annotations to enable methods that leverage large volumes of weakly-labeled data。For more information, please refer to the website.

--- a/LFX Mentorship Task1 from jaleWang
+++ b/LFX Mentorship Task1 from jaleWang
@@ -1,0 +1,2 @@
+A public link of the dataset benchmarking website : jaleWang.github.io
+The corresponding dataset introduction : Cityscapes is comprised of a large, diverse set of stereo video sequences recorded in streets from 50 different cities. 5000 of these images have high-quality pixel-level annotations; 20 000 additional images have coarse annotations to enable methods that leverage large volumes of weakly-labeled data。For more information, please refer to the website.


### PR DESCRIPTION

A public link of the dataset benchmarking website : jaleWang.github.io

The corresponding dataset introduction : Cityscapes is comprised of a large, diverse set of stereo video sequences recorded in streets from 50 different cities. 5000 of these images have high-quality pixel-level annotations; 20 000 additional images have coarse annotations to enable methods that leverage large volumes of weakly-labeled data. For more information, please refer to the website.