### PR TITLE
update CoC, point to kubeedge/community/CODE_OF_CONDUCT.md 

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,5 +1,3 @@
 # KubeEdge Community Code of Conduct
 
-KubeEdge follows the [CNCF Code of Conduct](https://github.com/cncf/foundation/blob/master/code-of-conduct.md).
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting the project team at kubeedge@gmail.com.
+Please refer to our [KubeEdge Community Code of Conduct](https://github.com/kubeedge/community/blob/master/CODE_OF_CONDUCT.md).


### PR DESCRIPTION
What type of PR is this?

/kind documentation

What this PR does / why we need it:

https://github.com/kubeedge/community/issues/158

update CoC to point to kubeedge/community/CODE_OF_CONDUCT.md