### PR TITLE
Fix incorrect preloading process of the Hard Example Mining module.

### DIFF
--- a/core/testcasecontroller/algorithm/module/module.py
+++ b/core/testcasecontroller/algorithm/module/module.py
@@ -110,9 +110,14 @@ class Module:
         if self.url:
             try:
                 utils.load_module(self.url)
-                # pylint: disable=E1134
-                func = ClassFactory.get_cls(
-                    type_name=class_factory_type, t_cls_name=self.name)(**self.hyperparameters)
+
+                if class_factory_type == ClassType.HEM:
+                    func = {"method": self.name, "param":self.hyperparameters}
+                else:
+                    func = ClassFactory.get_cls(
+                        type_name=class_factory_type,
+                        t_cls_name=self.name
+                    )(**self.hyperparameters)
 
                 return func
             except Exception as err:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/ianvs/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug
<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->


**What this PR does / why we need it**:

In current Ianvs implementation, the Hard Example Mining(HEM) Module will be loaded as a instance by `core/testcasecontroller/algorithm/module/module.py`.

However, both Incremental Learning and Joint Inference require Sedna itself to load this module, which causes issues in #136.

I solved the problem by adding an if-else branch to specially handle HEM to the parameter format required by Sedna during module loading.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #136
