### PR TITLE
rename yaml to fix sphinx

### DIFF
--- a/docs/.readthedocs.yaml
+++ b/docs/.readthedocs.yaml
@@ -1,5 +1,7 @@
 # Read the Docs configuration file for Sphinx projects
 # See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+# Note that the name of this file shall start with ".", i.e., ".readthedocs.yaml",
+# otherwise the system would have "cat yaml" error.
 
 # Required
 version: 2


### PR DESCRIPTION
What type of PR is this?
/kind bug

What this PR does / why we need it:
There are configuration and package-absent errors that are fixed with a Sphinx file name in this PR.
Note that the name of the readthedocs file shall start with ".", i.e., ".readthedocs.yaml", otherwise the system would have a "cat yaml" error.

Which issue(s) this PR fixes:
Related to https://github.com/kubeedge/ianvs/issues/145 and https://github.com/kubeedge/ianvs/issues/92