### PR TITLE
ubuntu runner in ci checks updated to use 22.04 instead of 20.04

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -23,7 +23,7 @@ on:
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
     strategy:
       fail-fast: false

--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       matrix:
         python-version: [ "3.7", "3.8", "3.9" ]

--- a/.github/workflows/main-doc.yaml
+++ b/.github/workflows/main-doc.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   pylint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: pylint
     strategy:
       matrix:

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   pylint:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     name: pylint
     strategy:
       matrix:


### PR DESCRIPTION
Fixes: #192 

/kind cleanup

