### PR TITLE
matplotlib added to ianvs project requirements to resolve pylint ci e…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ scikit-learn
 numpy
 pandas
 tqdm
+matplotlib


### PR DESCRIPTION
/kind cleanup


This PR fixes the CI workflow error as mentioned by #212:- 
```
Unable to import 'matplotlib.pyplot`
```
