### PR TITLE
Changed docs for installing iavns

### DIFF
--- a/docs/guides/how-to-install-ianvs.md
+++ b/docs/guides/how-to-install-ianvs.md
@@ -43,10 +43,22 @@ git clone https://github.com/kubeedge/ianvs.git
 ### Install third-party dependencies
 ```
 sudo apt-get update
+
+# Install OpenGL/GLX library for GUI support (required for OpenCV and visualization tools)
+# For Ubuntu 20.04 and earlier versions:
 sudo apt-get install libgl1-mesa-glx -y
+
+# For Ubuntu 24.04 and later versions (libgl1-mesa-glx has been renamed):
+sudo apt-get install libglx-mesa0 -y
+
+# Note: If you're unsure about your Ubuntu version, you can check it with:
+# lsb_release -a
+# Then use the appropriate command above
+
 python -m pip install --upgrade pip
 
-cd ~/ianvs 
+cd ~/ianvs
+
 python -m pip install ./examples/resources/third_party/*
 python -m pip install -r requirements.txt
 ```


### PR DESCRIPTION
What type of PR is this?
/kind documentation

What this PR does / why we need it:
This PR updates the installation documentation to address compatibility issues with Ubuntu 24.04+. In Ubuntu 24.04 and later versions, the libgl1-mesa-glx package has been renamed to libglx-mesa0, causing installation failures when users follow the current documentation.

Changes made:

Added explanatory comments about the OpenGL/GLX library purpose (required for OpenCV and visualization tools)
Provided separate installation commands for Ubuntu 20.04 and earlier vs Ubuntu 24.04+
Added instructions for users to check their Ubuntu version using lsb_release -a
Maintained backward compatibility for users on older Ubuntu versions
This ensures users on all Ubuntu versions can successfully install the required dependencies without encountering package availability errors.

Which issue(s) this PR fixes:
Fixes https://github.com/kubeedge/ianvs/issues/206