### PR TITLE
fix: enable EagleSpecDec backend and real resource router monitoring

### DIFF
--- a/examples/cloud-edge-collaborative-inference-for-llm/requirements.txt
+++ b/examples/cloud-edge-collaborative-inference-for-llm/requirements.txt
@@ -5,3 +5,4 @@ accelerate
 datamodel_code_generator
 kaggle
 groq
+psutil

--- a/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/edge_model.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/edge_model.py
@@ -44,9 +44,10 @@ class EdgeModel:
         self.kwargs = kwargs
         self.model_name = kwargs.get("model", None)
         self.backend = kwargs.get("backend", "huggingface")
-        if self.backend not in ["huggingface", "vllm", "api", "EagleSpecDec"]:
+        supported_backends = ["huggingface", "vllm", "api", "EagleSpecDec"]
+        if self.backend not in supported_backends:
             raise ValueError(
-                f"Unsupported backend: {self.backend}. Supported options are: 'huggingface', 'vllm', 'api', 'EagleSpecDec'."
+                f"Unsupported backend: {self.backend}. Supported options are: {', '.join(map(repr, supported_backends))}."
             )
         self._set_config()
 

--- a/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/edge_model.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/edge_model.py
@@ -18,7 +18,7 @@ import os
 
 from core.common.log import LOGGER
 from sedna.common.class_factory import ClassType, ClassFactory
-from models import HuggingfaceLLM, APIBasedLLM, VllmLLM, EagleSpecDecModel, LadeSpecDecLLM
+from models import HuggingfaceLLM, APIBasedLLM, VllmLLM, EagleSpecDecModel
 
 os.environ['BACKEND_TYPE'] = 'TORCH'
 
@@ -44,9 +44,9 @@ class EdgeModel:
         self.kwargs = kwargs
         self.model_name = kwargs.get("model", None)
         self.backend = kwargs.get("backend", "huggingface")
-        if self.backend not in ["huggingface", "vllm", "api"]:
+        if self.backend not in ["huggingface", "vllm", "api", "EagleSpecDec"]:
             raise ValueError(
-                f"Unsupported backend: {self.backend}. Supported options are: 'huggingface', 'vllm', 'api'."
+                f"Unsupported backend: {self.backend}. Supported options are: 'huggingface', 'vllm', 'api', 'EagleSpecDec'."
             )
         self._set_config()
 
@@ -73,8 +73,6 @@ class EdgeModel:
                 self.model = APIBasedLLM(**self.kwargs)
             elif self.backend == "EagleSpecDec":
                 self.model = EagleSpecDecModel(**self.kwargs)
-            elif self.backend == "LadeSpecDec":
-                self.model = LadeSpecDecLLM(**self.kwargs)
         except Exception as e:
             LOGGER.error(f"Failed to initialize model backend `{self.backend}`: {str(e)}")
             raise RuntimeError(f"Model loading failed for backend `{self.backend}`.") from e

--- a/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/hard_sample_mining.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/hard_sample_mining.py
@@ -310,12 +310,12 @@ class ResourceSensitiveRouterFilter(BaseFilter, abc.ABC):
         try:
             battery_info = psutil.sensors_battery()
             battery = battery_info.percent if battery_info else 100
-        except Exception:
-            battery = 100 # Assume full battery if not available
+        except (AttributeError, NotImplementedError):
+            battery = 100 #Assume full battery if not available
 
         return {
-            "temperature": 0, # psutil often cannot read temperature on all OSes without root or specific drivers
+            "temperature": 0, #psutil often cannot read temperature on all OSes without root or specific drivers
             "battery": battery,
-            "cpu": psutil.cpu_percent(interval=None),
+            "cpu": psutil.cpu_percent(interval=0.1),
             "memory": psutil.virtual_memory().percent
         }


### PR DESCRIPTION
**What type of PR is this?**

/kind feature

**What this PR does / why we need it**:

This PR addresses part of the cloud-edge multi-LLM routing paradigm by enabling Speculative Decoding backends and implementing real resource-aware routing.

Key changes:

1.  **Enable [EagleSpecDec](cci:2://file:///Users/krrishbiswas/Desktop/LFX/ianvs/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/eagle_llm.py:26:0-120:9) Backend**: Updated [EdgeModel](cci:2://file:///Users/krrishbiswas/Desktop/LFX/ianvs/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/edge_model.py:26:0-109:50) validation to accept [EagleSpecDec](cci:2://file:///Users/krrishbiswas/Desktop/LFX/ianvs/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/eagle_llm.py:26:0-120:9) as a valid backend for speculative decoding.

2.  **Remove Unimplemented Backend**: Removed references to `LadeSpecDecLLM` from [EdgeModel](cci:2://file:///Users/krrishbiswas/Desktop/LFX/ianvs/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/edge_model.py:26:0-109:50) as implementation is currently missing.

3.  **Real Resource Monitoring**: Updated [ResourceSensitiveRouterFilter](cci:2://file:///Users/krrishbiswas/Desktop/LFX/ianvs/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/hard_sample_mining.py:268:0-320:9) to use `psutil` for capturing real-time device metrics (CPU, Memory, Battery) instead of using mocked random values. This enables actual resource-aware routing decisions on edge devices.

**Which issue(s) this PR fixes**:

Fixes #202