### PR TITLE
fix: rename base_model_url to initial_model_url for consistency

### DIFF
--- a/core/testcasecontroller/algorithm/paradigm/incremental_learning/incremental_learning.py
+++ b/core/testcasecontroller/algorithm/paradigm/incremental_learning/incremental_learning.py
@@ -167,7 +167,7 @@ class IncrementalLearning(ParadigmBase):
             os.makedirs(train_output_dir)
 
         os.environ["MODEL_URL"] = train_output_dir
-        os.environ["BASE_MODEL_URL"] = model
+        os.environ["INITIAL_MODEL_URL"] = model
 
         job = self.build_paradigm_job(ParadigmType.INCREMENTAL_LEARNING.value)
         train_dataset = self.dataset.load_data(data_index_file, "train")

--- a/core/testcasecontroller/algorithm/paradigm/multiedge_inference/multiedge_inference.py
+++ b/core/testcasecontroller/algorithm/paradigm/multiedge_inference/multiedge_inference.py
@@ -81,7 +81,7 @@ class MultiedgeInference(ParadigmBase):
 
     def _inference(self, job, trained_model):
         train_dataset = self.dataset.load_data(self.dataset.train_url, "train")
-        os.environ["BASE_MODEL_URL"] = trained_model
+        os.environ["INITIAL_MODEL_URL"] = trained_model
         inference_dataset = self.dataset.load_data(self.dataset.test_url, "inference")
         inference_output_dir = os.path.join(self.workspace, "output/inference/")
         os.environ["RESULT_SAVED_URL"] = inference_output_dir

--- a/core/testcasecontroller/algorithm/paradigm/singletask_learning/singletask_learning.py
+++ b/core/testcasecontroller/algorithm/paradigm/singletask_learning/singletask_learning.py
@@ -117,7 +117,7 @@ class SingleTaskLearning(ParadigmBase):
 
     def _train(self, job, initial_model):
         train_output_dir = os.path.join(self.workspace, "output/train/")
-        os.environ["BASE_MODEL_URL"] = initial_model
+        os.environ["INITIAL_MODEL_URL"] = initial_model
 
         train_dataset = self.dataset.load_data(self.dataset.train_url, "train")
         job.train(train_dataset)

--- a/examples/Cloud_Robotics/singletask_learning_bench/Semantic_Segmentation/testalgorithms/basemodel.py
+++ b/examples/Cloud_Robotics/singletask_learning_bench/Semantic_Segmentation/testalgorithms/basemodel.py
@@ -67,7 +67,7 @@ class BaseModel:
         self.trainer = Trainer(self.train_cfgs)
         self.trainer.saver = Saver(self.train_cfgs)
         self.checkpoint_path = self.load(
-            Context.get_parameters("base_model_url"))
+            Context.get_parameters("initial_model_url"))
 
     def train(self, train_data, valid_data=None, **kwargs):
         if train_data is None or train_data.x is None or train_data.y is None:

--- a/examples/RoboDK Palletizing/singletask_learning_bench/testalgorithms/basemodel.py
+++ b/examples/RoboDK Palletizing/singletask_learning_bench/testalgorithms/basemodel.py
@@ -72,9 +72,9 @@ class BaseModel:
         self.model = YOLO(model_name)
         
         # Load pretrained model if specified
-        base_model_url = Context.get_parameters("base_model_url")
-        if base_model_url:
-            self.load(base_model_url)
+        initial_model_url = Context.get_parameters("initial_model_url")
+        if initial_model_url:
+            self.load(initial_model_url)
         
         logging.info(f"YOLOv8n initialized with {self.num_classes} classes")
     

--- a/examples/cityscapes/singletask_learning_bench/semantic-segmentation/testalgorithms/rfnet/basemodel.py
+++ b/examples/cityscapes/singletask_learning_bench/semantic-segmentation/testalgorithms/rfnet/basemodel.py
@@ -67,7 +67,7 @@ class BaseModel:
         self.trainer = Trainer(self.train_cfgs)
         self.trainer.saver = Saver(self.train_cfgs)
         self.checkpoint_path = self.load(
-            Context.get_parameters("base_model_url"))
+            Context.get_parameters("initial_model_url"))
 
     def train(self, train_data, valid_data=None, **kwargs):
         if train_data is None or train_data.x is None or train_data.y is None:

--- a/examples/pcb-aoi/incremental_learning_bench/fault_detection/testalgorithms/fpn/basemodel.py
+++ b/examples/pcb-aoi/incremental_learning_bench/fault_detection/testalgorithms/fpn/basemodel.py
@@ -236,7 +236,7 @@ class BaseModel:
 
             restorer = self._get_restorer()
             saver = tf.train.Saver(max_to_keep=3)
-            self.checkpoint_path = self.load(Context.get_parameters("base_model_url"))
+            self.checkpoint_path = self.load(Context.get_parameters("initial_model_url"))
 
             config = tf.ConfigProto()
             config.gpu_options.allow_growth = False

--- a/examples/pcb-aoi/singletask_learning_bench/fault_detection/testalgorithms/fpn/basemodel.py
+++ b/examples/pcb-aoi/singletask_learning_bench/fault_detection/testalgorithms/fpn/basemodel.py
@@ -236,7 +236,7 @@ class BaseModel:
 
             restorer = self._get_restorer()
             saver = tf.train.Saver(max_to_keep=3)
-            self.checkpoint_path = self.load(Context.get_parameters("base_model_url"))
+            self.checkpoint_path = self.load(Context.get_parameters("initial_model_url"))
 
             config = tf.ConfigProto()
             config.gpu_options.allow_growth = False


### PR DESCRIPTION
**What type of PR is this?**

/kind cleanup

**What this PR does / why we need it**:

This PR fixes a naming inconsistency in the codebase where:
- `algorithm.yaml` configuration files use `initial_model_url`
- But `basemodel.py` files were retrieving it as `base_model_url`

This was confusing for algorithm developers who had to know that setting `initial_model_url` in config required using `base_model_url` in code.

**Changes:**
- Core framework: Changed environment variable from `BASE_MODEL_URL` to `INITIAL_MODEL_URL` in:
  - `singletask_learning.py`
  - `incremental_learning.py`
  - `multiedge_inference.py`
- Examples: Updated `Context.get_parameters("base_model_url")` to `Context.get_parameters("initial_model_url")` in 5 basemodel.py files

**Which issue(s) this PR fixes**:

Fixes https://github.com/kubeedge/ianvs/issues/14

