### PR TITLE
Fix critical bugs blocking speculative decoding backend usage

### DIFF
--- a/examples/cloud-edge-collaborative-inference-for-llm/requirements.txt
+++ b/examples/cloud-edge-collaborative-inference-for-llm/requirements.txt
@@ -5,3 +5,4 @@ accelerate
 datamodel_code_generator
 kaggle
 groq
+retry

--- a/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/edge_model.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/edge_model.py
@@ -18,9 +18,12 @@ import os
 
 from core.common.log import LOGGER
 from sedna.common.class_factory import ClassType, ClassFactory
-from models import HuggingfaceLLM, APIBasedLLM, VllmLLM, EagleSpecDecModel, LadeSpecDecLLM
+from models import HuggingfaceLLM, APIBasedLLM, VllmLLM, EagleSpecDecModel
 
 os.environ['BACKEND_TYPE'] = 'TORCH'
+
+# Supported backend types for EdgeModel
+SUPPORTED_BACKENDS = ["huggingface", "vllm", "api", "EagleSpecDec"]
 
 __all__ = ["BaseModel"]
 
@@ -44,9 +47,9 @@ class EdgeModel:
         self.kwargs = kwargs
         self.model_name = kwargs.get("model", None)
         self.backend = kwargs.get("backend", "huggingface")
-        if self.backend not in ["huggingface", "vllm", "api"]:
+        if self.backend not in SUPPORTED_BACKENDS:
             raise ValueError(
-                f"Unsupported backend: {self.backend}. Supported options are: 'huggingface', 'vllm', 'api'."
+                f"Unsupported backend: {self.backend}. Supported options are: {SUPPORTED_BACKENDS}."
             )
         self._set_config()
 
@@ -73,8 +76,6 @@ class EdgeModel:
                 self.model = APIBasedLLM(**self.kwargs)
             elif self.backend == "EagleSpecDec":
                 self.model = EagleSpecDecModel(**self.kwargs)
-            elif self.backend == "LadeSpecDec":
-                self.model = LadeSpecDecLLM(**self.kwargs)
         except Exception as e:
             LOGGER.error(f"Failed to initialize model backend `{self.backend}`: {str(e)}")
             raise RuntimeError(f"Model loading failed for backend `{self.backend}`.") from e


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/ianvs/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR
-->

**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:

This PR fixes three critical bugs in the cloud-edge LLM example that were blocking speculative decoding backend functionality.

### Summary of Fixes:

1. **Missing `retry` dependency** - Adds the `retry` library to `requirements.txt`, which is imported and used by `api_llm.py` for handling API failures with automatic retries. Without this, API-based cloud inference fails immediately with `ModuleNotFoundError`.

2. **Backend validation excludes EagleSpecDec** - Updates the validation logic to include `EagleSpecDec` in the list of supported backends. The implementation for `EagleSpecDec` exists in the code but was being rejected by an outdated validation check, preventing users from benchmarking speculative decoding.

3. **Broken LadeSpecDecLLM import** - Removes references to `LadeSpecDecLLM`, which was imported but never implemented. This caused an `ImportError` on module load, blocking the entire `edge_model` module regardless of which backend users wanted to use.

### Changes Made:

**File: `examples/cloud-edge-collaborative-inference-for-llm/requirements.txt`**
- Added `retry` dependency

**File: `examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/edge_model.py`**
- Updated backend validation to include `EagleSpecDec` in supported backends list
- Introduced `SUPPORTED_BACKENDS` constant for better maintainability
- Removed `LadeSpecDecLLM` from imports (line 21)
- Removed `LadeSpecDec` backend handling block (lines 76-77)

### Impact:

- Enables speculative decoding backends (EagleSpecDec) to work as intended
- Fixes blocking issues for new contributors following the README setup instructions
- Unblocks API-based cloud inference for cloud-edge benchmarking scenarios
- Improves code maintainability with clearer validation logic

### Testing:

- ✅ **Syntax check**: `python3 -m py_compile edge_model.py` passes
- ✅ **Import verification**: Module imports successfully without errors
- ✅ **No regressions**: Verified existing backends (huggingface, vllm, api) still work
- ✅ **EagleSpecDec references preserved**: Confirmed `EagleSpecDec` implementation remains intact
- ✅ **LadeSpecDec cleanup**: Confirmed no remaining references to the unimplemented class

**Which issue(s) this PR fixes**:

Fixes #313
Fixes #312  
Fixes #311

---

### Additional Context:

I discovered these issues while exploring the cloud-edge LLM example setup and backend implementations. All three bugs are related to backend initialization and collectively prevented the example from being usable for speculative decoding scenarios. The fixes are minimal, focused, and don't introduce any breaking changes.

### Future Work:

If `LadeSpecDec` support is planned, I'm happy to contribute to implementing the `LadeSpecDecLLM` class following the same pattern as `EagleSpecDecModel` and other backends.