### PR TITLE
Fail early on Windows for vLLM-based cloud-edge LLM example

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,8 @@ dmypy.json
 .idea/misc.xml
 .idea/workspace.xml
 .idea/vcs.xml
+# Virtual environment
+ianvs-env/
+
+# Local verification script
+test_vllm_import.py

--- a/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/vllm_llm.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/vllm_llm.py
@@ -12,130 +12,122 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# ---------------------------------------------------------
+# Platform & dependency guard (MUST be first)
+# ---------------------------------------------------------
+import platform
+import importlib.util
+
+if platform.system() == "Windows":
+    raise RuntimeError(
+        "Cloud-edge LLM example requires Linux + GPU. "
+        "The vLLM backend is not supported on Windows."
+    )
+
+if importlib.util.find_spec("vllm") is None:
+    raise RuntimeError(
+        "vLLM is required for the cloud-edge LLM example but is not installed. "
+        "Please run this example on Linux with GPU support and install vllm."
+    )
+
+# ---------------------------------------------------------
+# Safe imports (only reached on supported platforms)
+# ---------------------------------------------------------
 import os
-import torch  
+import torch
 from vllm import LLM, SamplingParams
-from vllm.distributed.parallel_state import destroy_model_parallel, destroy_distributed_environment
+from vllm.distributed.parallel_state import (
+    destroy_model_parallel,
+    destroy_distributed_environment,
+)
 from models.base_llm import BaseLLM
 
+# ---------------------------------------------------------
+# Environment variables
+# ---------------------------------------------------------
 os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 os.environ["TOKENIZERS_PARALLELISM"] = "true"
 os.environ["VLLM_LOGGING_LEVEL"] = "ERROR"
 
 device = "cuda" if torch.cuda.is_available() else "cpu"
 
+
 class VllmLLM(BaseLLM):
     def __init__(self, **kwargs) -> None:
-        """ Initialize the VllmLLM class
+        """Initialize the VllmLLM class"""
 
-        Parameters
-        ----------
-        kwargs : dict
-            Parameters that are passed to the model. Details can be found in the BaseLLM class.
-
-            Special keys:
-            - `tensor_parallel_size`: int, default 1. Number of tensor parallelism.
-            - `gpu_memory_utilization`: float, default 0.8. GPU memory utilization.
-
-            See details about special parameters in [vLLM's Named Arguments](https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html).
-        """
-
-        BaseLLM.__init__(self, **kwargs)
+        super().__init__(**kwargs)
 
         self.tensor_parallel_size = kwargs.get("tensor_parallel_size", 1)
         self.gpu_memory_utilization = kwargs.get("gpu_memory_utilization", 0.8)
 
     def _load(self, model):
-        """Load the model via vLLM API
+        """Load the model via vLLM API"""
 
-        Parameters
-        ----------
-        model : str
-            Hugging Face style model name. Example: `Qwen/Qwen2.5-0.5B-Instruct`
-        """
         self.model = LLM(
             model=model,
             trust_remote_code=True,
             dtype="float16",
             tensor_parallel_size=self.tensor_parallel_size,
             gpu_memory_utilization=self.gpu_memory_utilization,
-            max_model_len = 8192
-            #quantization=self.quantization # TODO need to align with vllm API
+            max_model_len=8192,
+            # quantization=self.quantization  # TODO align with vLLM API
         )
 
         self.sampling_params = SamplingParams(
             temperature=self.temperature,
             top_p=self.top_p,
             repetition_penalty=self.repetition_penalty,
-            max_tokens=self.max_tokens
+            max_tokens=self.max_tokens,
         )
 
-        # Warmup to make metrics more accurate
+        # Warmup for accurate metrics
         self.warmup()
 
     def warmup(self):
-        """Warm up the Model for more accurate performance metrics
-        """
+        """Warm up the model"""
 
         try:
             self.model.chat(
                 [{"role": "user", "content": "Hello"}],
                 self.sampling_params,
-                use_tqdm=False
+                use_tqdm=False,
             )
         except Exception as e:
             raise RuntimeError(f"Warmup failed: {e}")
-        
+
     def _infer(self, messages):
-        """Call the vLLM Offline Inference API to get the response
-
-        Parameters
-        ----------
-        messages : list
-            OpenAI style message chain. Example:
-        ```
-        [{"role": "user", "content": "Hello, how are you?"}]
-        ```
-
-        Returns
-        -------
-        dict
-            Formatted Response. See `_format_response()` for more details.
-        """
+        """Run inference using vLLM"""
 
         outputs = self.model.chat(
             messages=messages,
             sampling_params=self.sampling_params,
-            use_tqdm=False
+            use_tqdm=False,
         )
+
         metrics = outputs[0].metrics
-        # Completion Text
         text = outputs[0].outputs[0].text
-        # Prompt Token Count
         prompt_tokens = len(outputs[0].prompt_token_ids)
-        # Completion Token Count
         completion_tokens = len(outputs[0].outputs[0].token_ids)
-        # Time to First Token (s)
+
         time_to_first_token = metrics.first_token_time - metrics.arrival_time
-        # Internal Token Latency (s)
-        internal_token_latency = (metrics.finished_time - metrics.first_token_time) / completion_tokens
-        # Completion Throughput (Token/s)
+        internal_token_latency = (
+            metrics.finished_time - metrics.first_token_time
+        ) / completion_tokens
         throughput = 1 / internal_token_latency
 
-        response = self._format_response(
+        return self._format_response(
             text,
             prompt_tokens,
             completion_tokens,
             time_to_first_token,
             internal_token_latency,
-            throughput
+            throughput,
         )
 
-        return response
-
     def cleanup(self):
-        """Release the model from GPU
-        """
+        """Release GPU resources"""
+
         try:
             destroy_model_parallel()
             destroy_distributed_environment()

--- a/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/vllm_llm.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/vllm_llm.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 # ---------------------------------------------------------
-# Platform & dependency guard (MUST be first)
+# Platform & dependency guard (fail early)
 # ---------------------------------------------------------
 import platform
 import importlib.util
+import torch
 
 if platform.system() == "Windows":
     raise RuntimeError(
@@ -30,11 +31,16 @@ if importlib.util.find_spec("vllm") is None:
         "Please run this example on Linux with GPU support and install vllm."
     )
 
+if not torch.cuda.is_available():
+    raise RuntimeError(
+        "Cloud-edge LLM example requires a GPU, but CUDA is not available. "
+        "Please run this example on a machine with a GPU and CUDA installed."
+    )
+
 # ---------------------------------------------------------
 # Safe imports (only reached on supported platforms)
 # ---------------------------------------------------------
 import os
-import torch
 from vllm import LLM, SamplingParams
 from vllm.distributed.parallel_state import (
     destroy_model_parallel,
@@ -49,21 +55,40 @@ os.environ["VLLM_WORKER_MULTIPROC_METHOD"] = "spawn"
 os.environ["TOKENIZERS_PARALLELISM"] = "true"
 os.environ["VLLM_LOGGING_LEVEL"] = "ERROR"
 
-device = "cuda" if torch.cuda.is_available() else "cpu"
-
 
 class VllmLLM(BaseLLM):
     def __init__(self, **kwargs) -> None:
-        """Initialize the VllmLLM class"""
+        """
+        Initialize the VllmLLM class.
 
+        Parameters
+        ----------
+        kwargs : dict
+            Parameters forwarded to the BaseLLM class.
+
+            Special keys:
+            - tensor_parallel_size : int, default 1
+                Number of tensor parallelism shards.
+            - gpu_memory_utilization : float, default 0.8
+                Fraction of GPU memory to use.
+
+        See vLLM named arguments:
+        https://docs.vllm.ai/en/latest/serving/openai_compatible_server.html
+        """
         super().__init__(**kwargs)
 
         self.tensor_parallel_size = kwargs.get("tensor_parallel_size", 1)
         self.gpu_memory_utilization = kwargs.get("gpu_memory_utilization", 0.8)
 
     def _load(self, model):
-        """Load the model via vLLM API"""
+        """
+        Load the model using the vLLM API.
 
+        Parameters
+        ----------
+        model : str
+            Hugging Face model identifier, e.g. `Qwen/Qwen2.5-0.5B-Instruct`
+        """
         self.model = LLM(
             model=model,
             trust_remote_code=True,
@@ -71,7 +96,6 @@ class VllmLLM(BaseLLM):
             tensor_parallel_size=self.tensor_parallel_size,
             gpu_memory_utilization=self.gpu_memory_utilization,
             max_model_len=8192,
-            # quantization=self.quantization  # TODO align with vLLM API
         )
 
         self.sampling_params = SamplingParams(
@@ -81,12 +105,13 @@ class VllmLLM(BaseLLM):
             max_tokens=self.max_tokens,
         )
 
-        # Warmup for accurate metrics
+        # Warm up for accurate performance metrics
         self.warmup()
 
     def warmup(self):
-        """Warm up the model"""
-
+        """
+        Perform a warm-up inference to stabilize performance metrics.
+        """
         try:
             self.model.chat(
                 [{"role": "user", "content": "Hello"}],
@@ -97,8 +122,19 @@ class VllmLLM(BaseLLM):
             raise RuntimeError(f"Warmup failed: {e}")
 
     def _infer(self, messages):
-        """Run inference using vLLM"""
+        """
+        Run inference using vLLM.
 
+        Parameters
+        ----------
+        messages : list
+            OpenAI-style message list.
+
+        Returns
+        -------
+        dict
+            Formatted inference response including latency and throughput.
+        """
         outputs = self.model.chat(
             messages=messages,
             sampling_params=self.sampling_params,
@@ -126,8 +162,9 @@ class VllmLLM(BaseLLM):
         )
 
     def cleanup(self):
-        """Release GPU resources"""
-
+        """
+        Release GPU and distributed resources.
+        """
         try:
             destroy_model_parallel()
             destroy_distributed_environment()


### PR DESCRIPTION
### What this PR does
Adds an early platform check for the cloud-edge collaborative LLM example.

### Why this is needed
The example depends on vLLM, which does not support Windows or CPU-only
environments. Previously, running the example on Windows resulted in a
late ModuleNotFoundError. This change fails early with a clear, actionable
error message.

### Tested
- Windows 11 (CPU-only)
- Verified that the example fails early with a clear RuntimeError

Fixes #310
