### PR TITLE
fix(examples): add missing runtime dependencies for cloud-edge LLM example

### DIFF
--- a/examples/cloud-edge-collaborative-inference-for-llm/requirements.txt
+++ b/examples/cloud-edge-collaborative-inference-for-llm/requirements.txt
@@ -1,3 +1,18 @@
+prettytable~=2.5.0  # BSD
+scikit-learn
+numpy
+pandas
+tqdm
+matplotlib
+onnx
+
+# --- Missing runtime dependencies (imported in code) ---
+retry            # used by APIBasedLLM
+colorlog         # used by core/common/log.py
+
+pyyaml           # used for config parsing
+openai           # APIBasedLLM backend
+groq             # APIBasedLLM backend
 vllm
 transformers
 openai


### PR DESCRIPTION
### What does this PR do?

Fixes missing runtime dependencies in the
`examples/cloud-edge-collaborative-inference-for-llm` example that cause
sequential `ModuleNotFoundError` failures in a fresh environment.

### Issues observed

Running the example fails due to missing dependencies:
- `prettytable` – result visualization
- `onnx` – required by MultiedgeInference
- `retry` – required by API-based LLM module
- `colorlog`, `pyyaml` – required by ianvs runtime
- Rust/Cargo – required for building `tokenizers`

These were not fully documented or included in the example requirements,
blocking new users from running the benchmark successfully.

### What was changed

- Updated `examples/cloud-edge-collaborative-inference-for-llm/requirements.txt`
  to include missing Python runtime dependencies
- Aligns example dependencies with actual imports used at runtime

### How it was tested

- Fresh conda environment (Python 3.8)
- Ubuntu Linux (WSL2)
- Reproduced failures, installed dependencies, verified progress

### Related issue

Fixes #322
