### PR TITLE
fix: Add missing dependencies and remove dead import in cloud-edge LLM example

### DIFF
--- a/examples/cloud-edge-collaborative-inference-for-llm/requirements.txt
+++ b/examples/cloud-edge-collaborative-inference-for-llm/requirements.txt
@@ -5,3 +5,4 @@ accelerate
 datamodel_code_generator
 kaggle
 groq
+retry

--- a/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/edge_model.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/edge_model.py
@@ -18,7 +18,7 @@ import os
 
 from core.common.log import LOGGER
 from sedna.common.class_factory import ClassType, ClassFactory
-from models import HuggingfaceLLM, APIBasedLLM, VllmLLM, EagleSpecDecModel, LadeSpecDecLLM
+from models import HuggingfaceLLM, APIBasedLLM, VllmLLM, EagleSpecDecModel
 
 os.environ['BACKEND_TYPE'] = 'TORCH'
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ pandas
 tqdm
 matplotlib
 onnx
+colorlog>=6.10.0  
+./examples/resources/third_party/sedna-0.6.0.1-py3-none-any.whl


### PR DESCRIPTION
**Description:**

## Problem

The cloud-edge collaborative inference for LLM example fails to run on fresh installations due to missing dependencies and a dead code import. This affects new users trying to run this example.

## What This PR Fixes

This PR fixes 4  bugs that block the example from running:

1. Missing `sedna` Framework
2. Missing `colorlog` Dependency
3. Missing `retry` Dependency
4. Dead Import `LadeSpecDecLLM`
## Changes Made

**Files Modified:**
- `requirements.txt` - Added `colorlog` and `sedna`
- `examples/cloud-edge-collaborative-inference-for-llm/requirements.txt` - Added `retry`
- `examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/edge_model.py` - Removed dead import

## Testing

Tested on  Ubuntu 24.04 installation:
```bash
python3 -m venv venv
source venv/bin/activate
pip install -r requirements.txt
pip install -e .
pip install -r examples/cloud-edge-collaborative-inference-for-llm/requirements.txt

# All imports now work correctly
ianvs -f examples/cloud-edge-collaborative-inference-for-llm/benchmarkingjob.yaml
# Benchmark runs successfully
```

## Additional Context

Discovered during LFX Mentorship 2026 pre-test for Issue #304 (Cloud-Edge Simulation Benchmark for LLM Speculative Decoding).

## Related Issues

Fixes #333 
```
