### PR TITLE
fix: replace 'and' with 'or' in _check_fields validation logic

### DIFF
--- a/core/cmd/obj/benchmarkingjob.py
+++ b/core/cmd/obj/benchmarkingjob.py
@@ -51,14 +51,14 @@ class BenchmarkingJob:
         self._parse_config(config)
 
     def _check_fields(self):
-        if not self.name and not isinstance(self.name, str):
+        if not self.name or not isinstance(self.name, str):
             raise ValueError(f"benchmarkingjob's name({self.name}) must be provided"
                              f" and be string type.")
 
         if not isinstance(self.workspace, str):
             raise ValueError(f"benchmarkingjob's workspace({self.workspace}) must be string type.")
 
-        if not self.test_object and not isinstance(self.test_object, dict):
+        if not self.test_object or not isinstance(self.test_object, dict):
             raise ValueError(f"benchmarkingjob's test_object({self.test_object})"
                              f" must be dict type.")
 

--- a/core/storymanager/rank/rank.py
+++ b/core/storymanager/rank/rank.py
@@ -58,18 +58,18 @@ class Rank:
         self._check_fields()
 
     def _check_fields(self):
-        if not self.sort_by and not isinstance(self.sort_by, list):
+        if not self.sort_by or not isinstance(self.sort_by, list):
             raise ValueError(
                 f"rank's sort_by({self.sort_by}) must be provided and be list type."
             )
 
-        if not self.visualization and not isinstance(self.visualization, dict):
+        if not self.visualization or not isinstance(self.visualization, dict):
             raise ValueError(
                 f"rank's visualization({self.visualization}) "
                 f"must be provided and be dict type."
             )
 
-        if not self.selected_dataitem and not isinstance(self.selected_dataitem, dict):
+        if not self.selected_dataitem or not isinstance(self.selected_dataitem, dict):
             raise ValueError(
                 f"rank's selected_dataitem({self.selected_dataitem}) "
                 f"must be provided and be dict type."
@@ -84,7 +84,7 @@ class Rank:
         if not self.selected_dataitem.get("metrics"):
             raise ValueError("not found metrics of selected_dataitem in rank.")
 
-        if not self.save_mode and not isinstance(self.save_mode, list):
+        if not self.save_mode or not isinstance(self.save_mode, list):
             raise ValueError(
                 f"rank's save_mode({self.save_mode}) "
                 f"must be provided and be list type."

--- a/core/testcasecontroller/algorithm/algorithm.py
+++ b/core/testcasecontroller/algorithm/algorithm.py
@@ -130,10 +130,10 @@ class Algorithm:
         return None
 
     def _check_fields(self):
-        if not self.name and not isinstance(self.name, str):
+        if not self.name or not isinstance(self.name, str):
             raise ValueError(f"algorithm name({self.name}) must be provided and be string type.")
 
-        if not self.paradigm_type and not isinstance(self.paradigm_type, str):
+        if not self.paradigm_type or not isinstance(self.paradigm_type, str):
             raise ValueError(
                 f"algorithm paradigm({self.paradigm_type}) must be provided and be string type.")
 

--- a/core/testcasecontroller/algorithm/module/module.py
+++ b/core/testcasecontroller/algorithm/module/module.py
@@ -58,7 +58,7 @@ class Module:
         self._parse_config(config)
 
     def _check_fields(self):
-        if not self.type and not isinstance(self.type, str):
+        if not self.type or not isinstance(self.type, str):
             raise ValueError(f"module type({self.type}) must be provided and be string type.")
 
         types = [e.value for e in ModuleType.__members__.values()]
@@ -66,7 +66,7 @@ class Module:
             raise ValueError(f"not support module type({self.type}."
                              f"the following paradigms can be selected: {types}")
 
-        if not self.name and not isinstance(self.name, str):
+        if not self.name or not isinstance(self.name, str):
             raise ValueError(f"module name({self.name}) must be provided and be string type.")
 
         if not isinstance(self.url, str):


### PR DESCRIPTION
Fix incorrect logical operator in _check_fields() across 4 core modules (10 instances). Using 'and' caused invalid inputs to silently pass validation. Changed to 'or' so ValueError is raised when either the field is falsy or the wrong type.

Fixes #335

**What type of PR is this?**
/kind bug


**What this PR does / why we need it**:
Fixes incorrect logical operator (`and` → `or`) in `_check_fields()` validation across 4 core modules (10 instances).

**Problem:** Using `and` meant errors were raised only when **both** conditions were true, allowing invalid inputs (empty strings, wrong types) to pass silently:
```python
# Before (incorrect)
if not self.name and not isinstance(self.name, str):  # ❌
```

**Solution:** Changed to `or` so validation fails when **either** condition is true:
```python
# After (correct)
if not self.name or not isinstance(self.name, str):  # ✅
```

**Impact:** Now properly rejects:
- Empty strings: `self.name = ""`
- Wrong types: `self.name = 123`
- None values: `self.name = None`

**Files Changed:**
- `core/cmd/obj/benchmarkingjob.py` (2 fixes)
- `core/storymanager/rank/rank.py` (4 fixes)
- `core/testcasecontroller/algorithm/algorithm.py` (2 fixes)
- `core/testcasecontroller/algorithm/module/module.py` (2 fixes)

**Which issue(s) this PR fixes**:
Fixes #335

### 1. Code Comparison
<img width="835" height="431" alt="image" src="https://github.com/user-attachments/assets/fb78003e-cf0a-410a-8771-a90b57f16b89" />

