### PR TITLE
 Fix KeyError crashes and division by zero in LLM inference benchmark

### DIFF
--- a/examples/cloud-edge-collaborative-inference-for-llm/testenv/result_parser.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testenv/result_parser.py
@@ -43,14 +43,16 @@ class Response:
         """
 
         if response:
+            usage = response.get("usage", {})
+            perf = response.get("perf", {})
             return cls(
-                response["completion"],
-                response["usage"]["prompt_tokens"],
-                response["usage"]["completion_tokens"],
-                response["usage"]["total_tokens"],
-                response["perf"]["time_to_first_token"],
-                response["perf"]["internal_token_latency"],
-                response["perf"]["throughput"]
+                response.get("completion", ""),
+                usage.get("prompt_tokens", 0),
+                usage.get("completion_tokens", 0),
+                usage.get("total_tokens", 0),
+                perf.get("time_to_first_token", 0),
+                perf.get("internal_token_latency", 0),
+                perf.get("throughput", 0)
             )
         else:
             return cls("", 0, 0, 0, 0, 0, 0)

--- a/examples/cloud-edge-collaborative-inference-for-llm/testenv/throughput.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testenv/throughput.py
@@ -34,7 +34,13 @@ def throughput(_, y_pred):
 
     infer_res = [JointInferenceResult.from_list(*pred) for pred in y_pred]
 
+    if not infer_res:
+        return 0.0
+
     average_itl = sum([pred.result.internal_token_latency for pred in infer_res]) / len(infer_res)
+
+    if average_itl == 0:
+        return 0.0
 
     average_throughput = 1 / average_itl
 


### PR DESCRIPTION

### Problem
The cloud-edge-collaborative-inference-for-llm benchmark crashes with KeyError and ZeroDivisionError during execution, preventing successful completion of benchmarking runs.

### Solution
This PR makes the response parsing and metric calculations more robust:

1. **result_parser.py**: Replace direct dictionary access with `.get()` methods and default values
2. **throughput.py**: Add zero-division check before calculating throughput

### Changes Made

#### 1. `testenv/result_parser.py`
- Changed from `response["key"]` to `response.get("key", default)`
- Added nested `.get()` for "usage" and "perf" dictionaries
- Provides sensible defaults (empty strings for text, 0 for numeric values)
- Ensures graceful handling of incomplete response structures

#### 2. `testenv/throughput.py`
- Added check: `if average_itl == 0: return 0.0`
- Prevents ZeroDivisionError when internal_token_latency is 0
- Returns 0.0 throughput when metrics are unavailable

### Testing
✅ Benchmark now runs successfully without crashes
✅ Handles incomplete response structures gracefully
✅ Metrics compute correctly even with zero values
✅ No regression in functionality
<img width="580" height="815" alt="Screenshot from 2026-02-10 21-36-38" src="https://github.com/user-attachments/assets/a0d0a3e2-43e8-401b-b570-15a79be16748" />
<img width="580" height="815" alt="Screenshot from 2026-02-10 21-36-30" src="https://github.com/user-attachments/assets/1f6a98ce-28c8-4fee-9949-25cacf0b0a94" />
