### PR TITLE
chore(ci): update github actions versions

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -15,9 +15,9 @@ jobs:
       matrix:
         python-version: [ "3.7", "3.8", "3.9" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: run FOSSA analysis

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -17,9 +17,9 @@ jobs:
       matrix:
         python-version: [ "3.7", "3.8", "3.9" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies


### PR DESCRIPTION
### CI: Fix Node 16 deprecation warnings by updating actions

**Description**
The current CI workflows are using older versions of `checkout` and `setup-python` (v3), which rely on the now-deprecated Node 16 runtime. This is starting to trigger warnings in the build logs and will eventually stop working.

I've gone through and updated the workflows to use the latest stable versions:
- Bumped `actions/checkout` to **v4**
- Bumped `actions/setup-python` to **v5**

This covers [main.yaml](cci:7://file:///home/shanu/ianvs-1/.github/workflows/main.yaml:0:0-0:0), [fossa.yaml](cci:7://file:///home/shanu/ianvs-1/.github/workflows/fossa.yaml:0:0-0:0), and [codeql-analysis.yml](cci:7://file:///home/shanu/ianvs-1/.github/workflows/codeql-analysis.yml:0:0-0:0) to ensure everything is consistent and up to date.
fixes #349