### PR TITLE
fix(examples): add missing requirements.txt for robot and cifar100

### DIFF
--- a/examples/cifar100/requirements.txt
+++ b/examples/cifar100/requirements.txt
@@ -1,0 +1,3 @@
+keras
+sedna
+tensorflow

--- a/examples/robot/requirements.txt
+++ b/examples/robot/requirements.txt
@@ -1,0 +1,8 @@
+fastapi
+opencv-python-headless
+Pillow
+pydantic
+sedna
+torch
+torchvision
+uvicorn


### PR DESCRIPTION
Added requirements.txt files for the robot and cifar100 examples.
This fixes the issue where users couldn't find the dependencies for these examples.
Fixes #351.
@hsj576 