### PR TITLE
fix: add missing retry dependency to LLM example requirements

### DIFF
--- a/examples/cloud-edge-collaborative-inference-for-llm/requirements.txt
+++ b/examples/cloud-edge-collaborative-inference-for-llm/requirements.txt
@@ -5,3 +5,4 @@ accelerate
 datamodel_code_generator
 kaggle
 groq
+retry


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

This PR fixes a missing dependency in the cloud-edge collaborative inference for LLM example. The code imports the `retry` package in `testalgorithms/query-routing/models/api_llm.py` but doesn't list it in `requirements.txt`, causing a `ModuleNotFoundError` at runtime when users try to run the example.

This prevents new users from successfully running the LLM example following the documentation.

**Which issue(s) this PR fixes**:

N/A - This issue was discovered during a complete reproduction of the example from scratch.

**Additional context**:

- **Root Cause**: Line 21 of `testalgorithms/query-routing/models/api_llm.py` contains `from retry import retry`, but the `retry` package is not listed in the example's requirements.txt
- **Impact**: The benchmark fails immediately on startup with `ModuleNotFoundError` before any inference can run
- **Fix**: Added `retry` as a dependency in `examples/cloud-edge-collaborative-inference-for-llm/requirements.txt`
- **Testing**: Verified the fix resolves the import error. The benchmark initializes successfully and proceeds past the module loading stage.

**Reproduction steps (before fix)**:
1. Build Docker image: `docker build -t ianvs-experiment-image ./examples/cloud-edge-collaborative-inference-for-llm/`
2. Run container and activate conda environment
3. Execute: `ianvs -f examples/cloud-edge-collaborative-inference-for-llm/benchmarkingjob.yaml`
4. Result: `ModuleNotFoundError: No module named 'retry'`

**After fix**: The `ModuleNotFoundError` is resolved.
