### PR TITLE
fix(examples): resolve broken paths in MDIL-SS configuration

### DIFF
--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/benchmarkingjob.yaml
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/benchmarkingjob.yaml
@@ -6,7 +6,7 @@ benchmarkingjob:
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;
-  testenv: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testenv/testenv.yaml"
+  testenv: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testenv/testenv.yaml"
 
   # the configuration of test object
   test_object:
@@ -19,7 +19,7 @@ benchmarkingjob:
       - name: "erfnet_lifelong_learning"
         # the url address of test algorithm configuration file; string type;
         # the file format supports yaml/yml
-        url: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testalgorithms/erfnet/test_algorithm.yaml"
+        url: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/test_algorithm.yaml"
 
   # the configuration of ranking leaderboard
   rank:

--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/test_algorithm.yaml
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/test_algorithm.yaml
@@ -25,7 +25,7 @@ algorithm:
       # example: basemodel.py has BaseModel module that the alias is "FPN" for this benchmarking;
       name: "BaseModel"
       # the url address of python module; string type;
-      url: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testalgorithms/erfnet/basemodel.py"
+      url: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/basemodel.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -40,7 +40,7 @@ algorithm:
       # name of python module; string type;
       name: "TaskDefinitionByDomain"
       # the url address of python module; string type;
-      url: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testalgorithms/erfnet/task_definition_by_domain.py"
+      url: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/task_definition_by_domain.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -53,7 +53,7 @@ algorithm:
       # name of python module; string type;
       name: "TaskAllocationByDomain"
       # the url address of python module; string type;
-      url: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testalgorithms/erfnet/task_allocation_by_domain.py"
+      url: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/task_allocation_by_domain.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;

--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testenv/testenv.yaml
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testenv/testenv.yaml
@@ -2,9 +2,9 @@ testenv:
   # dataset configuration
   dataset:
     # the url address of train dataset index; string type;
-    train_url: "/home/QXY/dataset/mdil-ss/train/mdil-ss-train-index-small.txt"
+    train_url: "./dataset/mdil-ss/train/mdil-ss-train-index-small.txt"
     # the url address of test dataset index; string type;
-    test_url: "/home/QXY/dataset/mdil-ss/test/mdil-ss-test-index-small.txt"
+    test_url: "./dataset/mdil-ss/test/mdil-ss-test-index-small.txt"
 
   # model eval configuration of incremental learning;
   model_eval:
@@ -13,7 +13,7 @@ testenv:
       # metric name; string type;
       name: "accuracy"
       # the url address of python file
-      url: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testenv/accuracy.py"
+      url: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testenv/accuracy.py"
       mode: "no-inference"
 
     # condition of triggering inference model to update
@@ -28,7 +28,7 @@ testenv:
       # metric name; string type;
     - name: "accuracy"
       # the url address of python file
-      url: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testenv/accuracy.py"
+      url: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testenv/accuracy.py"
     - name: "samples_transfer_ratio"
     - name: "task_avg_acc"
     - name: "BWT"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time, please read our contributor guidelines:
https://github.com/kubeedge/ianvs/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug

<!--
Add one of the following kinds:
/kind bug
/kind cleanup
/kind documentation
/kind feature
/kind test
/kind design

Optionally add one or more of the following kinds if applicable:
/kind api-change
/kind failing-test
-->

**What this PR does / why we need it**:
The implementation for the MDIL-SS incremental learning algorithm was previously merged in PR #85 under `examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation`. However, the YAML configuration files inside that folder contained hardcoded paths belonging to a specific local machine (e.g. `/home/QXY/dataset/...`) and referenced a non-existent `class_increment_semantic_segmentation` directory. 

This PR fixes those broken paths by substituting them with the correct relative workspace paths, allowing users to successfully run the MDIL-SS benchmarking job. 

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
-->
Fixes #79
