### PR TITLE
fix: resolve path errors and hard-coded dependencies in semantic segmentation example

### DIFF
--- a/examples/robot/lifelong_learning_bench/semantic-segmentation/benchmarkingjob-sam.yaml
+++ b/examples/robot/lifelong_learning_bench/semantic-segmentation/benchmarkingjob-sam.yaml
@@ -3,13 +3,9 @@ benchmarkingjob:
   name: "benchmarkingjob"
   # the url address of job workspace that will reserve the output of tests; string type;
   workspace: "/ianvs/sam_bench/robot-workspace"
-  #workspace: "/home/hsj/ianvs/sam_bench/cloud-robot-workspace"
-
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;
-  testenv: "./examples/robot/lifelong_learning_bench/testenv/testenv-robot-small.yaml"
-  #testenv: "./examples/robot/lifelong_learning_bench/testenv/testenv-robot.yaml"
-
+  testenv: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/testenv-robot-small.yaml"
   # the configuration of test object
   test_object:
     # test type; string type;
@@ -18,19 +14,10 @@ benchmarkingjob:
     # test algorithm configuration files; list type;
     algorithms:
       # algorithm name; string type;
-      #- name: "rfnet_lifelong_learning"
       - name: "sam_rfnet_lifelong_learning"
-      #- name: "vit_lifelong_learning"
-      #- name: "sam_vit_lifelong_learning"
         # the url address of test algorithm configuration file; string type;
         # the file format supports yaml/yml
-        #url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/rfnet_algorithm.yaml"
-        url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/sam_algorithm.yaml"
-        #url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/vit_algorithm.yaml"
-        #url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/sam_vit_algorithm.yaml"
-        # the url address of test algorithm configuration file; string type;
-        # the file format supports yaml/yml
-
+        url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/sam_algorithm.yaml"
   # the configuration of ranking leaderboard
   rank:
     # rank leaderboard with metric of test case's evaluation and order ; list type;

--- a/examples/robot/lifelong_learning_bench/semantic-segmentation/benchmarkingjob-simple.yaml
+++ b/examples/robot/lifelong_learning_bench/semantic-segmentation/benchmarkingjob-simple.yaml
@@ -6,7 +6,7 @@ benchmarkingjob:
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;
-  testenv: "./examples/robot/lifelong_learning_bench/testenv/testenv-robot.yaml"
+  testenv: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/testenv-robot.yaml"
 
   # the configuration of test object
   test_object:
@@ -19,7 +19,7 @@ benchmarkingjob:
       - name: "rfnet_lifelong_learning"
         # the url address of test algorithm configuration file; string type;
         # the file format supports yaml/yml
-        url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/rfnet_algorithm-simple.yaml"
+        url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/rfnet_algorithm-simple.yaml"
 
   # the configuration of ranking leaderboard
   rank:

--- a/examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/RFNet/eval.py
+++ b/examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/RFNet/eval.py
@@ -162,14 +162,14 @@ class Validator(object):
         return sum_3
     
     def sam_predict_ssa(self, image_name, pred):
-        with open('/home/hsj/ianvs/project/cache.pickle', 'rb') as file:
+        with open('/ianvs/project/cache.pickle', 'rb') as file:
             cache = pickle.load(file)
         img = mmcv.imread(image_name)
         if image_name in cache.keys():
             mask = cache[image_name]
             print("load cache")
         else:
-            sam = sam_model_registry["vit_h"](checkpoint="/home/hsj/ianvs/project/segment-anything/sam_vit_h_4b8939.pth").to('cuda:1')
+            sam = sam_model_registry["vit_h"](checkpoint="/ianvs/project/segment-anything/sam_vit_h_4b8939.pth").to('cuda:1')
             mask_branch_model = SamAutomaticMaskGenerator(
                 model=sam,
                 #points_per_side=64,
@@ -184,7 +184,7 @@ class Validator(object):
             print('[Model loaded] Mask branch (SAM) is loaded.')
             mask = mask_branch_model.generate(img)
             cache[image_name] = mask
-            with open('/home/hsj/ianvs/project/cache.pickle', 'wb') as file:
+            with open('/ianvs/project/cache.pickle', 'wb') as file:
                 pickle.dump(cache, file)
                 print("save cache")
 
@@ -234,14 +234,14 @@ class Validator(object):
         return semantc_mask, mask
 
     def sam_predict(self, image_name, pred):
-        with open('/home/hsj/ianvs/project/cache.pickle', 'rb') as file:
+        with open('/ianvs/project/cache.pickle', 'rb') as file:
             cache = pickle.load(file)
         img = mmcv.imread(image_name)
         if image_name in cache.keys():
             mask = cache[image_name]
             print("load cache")
         else:
-            sam = sam_model_registry["vit_h"](checkpoint="/home/hsj/ianvs/project/segment-anything/sam_vit_h_4b8939.pth").to('cuda:1')
+            sam = sam_model_registry["vit_h"](checkpoint="/ianvs/project/segment-anything/sam_vit_h_4b8939.pth").to('cuda:1')
             mask_branch_model = SamAutomaticMaskGenerator(
                 model=sam,
                 #points_per_side=64,
@@ -256,7 +256,7 @@ class Validator(object):
             print('[Model loaded] Mask branch (SAM) is loaded.')
             mask = mask_branch_model.generate(img)
             cache[image_name] = mask
-            with open('/home/hsj/ianvs/project/cache.pickle', 'wb') as file:
+            with open('/ianvs/project/cache.pickle', 'wb') as file:
                 pickle.dump(cache, file)
                 print("save cache")
 

--- a/examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/basemodel.py
+++ b/examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/basemodel.py
@@ -46,7 +46,7 @@ class BaseModel:
             train_loss = self.trainer.my_training(epoch)
             #train_loss = self.trainer.training(epoch)
             loss_all.append(train_loss)
-        with open('/home/shijing.hu/ianvs/project/ianvs/train_loss_2.txt', 'a+') as file:
+        with open('/ianvs/project/ianvs/train_loss_2.txt', 'a+') as file:
             np.savetxt(file, loss_all)
         file.close
 
@@ -83,7 +83,7 @@ class BaseModel:
                 }, is_best)
 
         self.trainer.writer.close()
-        with open('/home/shijing.hu/ianvs/project/ianvs/train_loss.txt', 'a+') as file:
+        with open('/ianvs/project/ianvs/train_loss.txt', 'a+') as file:
             np.savetxt(file, loss_all)
         file.close
         return self.train_model_url

--- a/examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/rfnet_algorithm-simple.yaml
+++ b/examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/rfnet_algorithm-simple.yaml
@@ -12,7 +12,6 @@ algorithm:
     # the method of splitting dataset; string type; optional;
     # currently the options of value are as follows:
     #   1> "default": the dataset is evenly divided based train_ratio;
-    #splitting_method: "default"
     splitting_method: "fwt_splitting"
 
   # algorithm module configuration in the paradigm; list type;
@@ -25,7 +24,7 @@ algorithm:
       # example: basemodel.py has BaseModel module that the alias is "FPN" for this benchmarking;
       name: "BaseModel"
       # the url address of python module; string type;
-      url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/basemodel-simple.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/basemodel-simple.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -40,7 +39,7 @@ algorithm:
       # name of python module; string type;
       name: "TaskDefinitionByOrigin"
       # the url address of python module; string type;
-      url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/task_definition_by_origin-simple.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/task_definition_by_origin-simple.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -53,7 +52,7 @@ algorithm:
       # name of python module; string type;
       name: "TaskAllocationByOrigin"
       # the url address of python module; string type;
-      url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/task_allocation_by_origin-simple.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/task_allocation_by_origin-simple.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;

--- a/examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/rfnet_algorithm.yaml
+++ b/examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/rfnet_algorithm.yaml
@@ -12,8 +12,6 @@ algorithm:
     # the method of splitting dataset; string type; optional;
     # currently the options of value are as follows:
     #   1> "default": the dataset is evenly divided based train_ratio;
-    #splitting_method: "default"
-    #splitting_method: "fwt_splitting"
     splitting_method: "hard-example_splitting"
 
   # algorithm module configuration in the paradigm; list type;
@@ -26,7 +24,7 @@ algorithm:
       # example: basemodel.py has BaseModel module that the alias is "FPN" for this benchmarking;
       name: "BaseModel"
       # the url address of python module; string type;
-      url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/basemodel-simple.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/basemodel-simple.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -41,7 +39,7 @@ algorithm:
       # name of python module; string type;
       name: "TaskDefinitionByOrigin"
       # the url address of python module; string type;
-      url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/task_definition_by_origin-simple.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/task_definition_by_origin-simple.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -54,7 +52,7 @@ algorithm:
       # name of python module; string type;
       name: "TaskAllocationByOrigin"
       # the url address of python module; string type;
-      url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/task_allocation_by_origin-simple.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/task_allocation_by_origin-simple.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -67,7 +65,7 @@ algorithm:
       # name of python module; string type;
       name: "HardSampleMining"
       # the url address of python module; string type;
-      url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/hard_sample_mining.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/hard_sample_mining.py"
       hyperparameters:
         - threhold:
             values:

--- a/examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/sam_algorithm.yaml
+++ b/examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/sam_algorithm.yaml
@@ -12,8 +12,6 @@ algorithm:
     # the method of splitting dataset; string type; optional;
     # currently the options of value are as follows:
     #   1> "default": the dataset is evenly divided based train_ratio;
-    #splitting_method: "default"
-    #splitting_method: "fwt_splitting"
     splitting_method: "hard-example_splitting"
 
   # algorithm module configuration in the paradigm; list type;
@@ -26,7 +24,7 @@ algorithm:
       # example: basemodel.py has BaseModel module that the alias is "FPN" for this benchmarking;
       name: "BaseModel"
       # the url address of python module; string type;
-      url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/basemodel-sam.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/basemodel-sam.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -41,7 +39,7 @@ algorithm:
       # name of python module; string type;
       name: "TaskDefinitionByOrigin"
       # the url address of python module; string type;
-      url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/task_definition_by_origin-simple.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/task_definition_by_origin-simple.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -54,7 +52,7 @@ algorithm:
       # name of python module; string type;
       name: "TaskAllocationByOrigin"
       # the url address of python module; string type;
-      url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/task_allocation_by_origin-simple.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/task_allocation_by_origin-simple.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -67,7 +65,7 @@ algorithm:
       # name of python module; string type;
       name: "HardSampleMining"
       # the url address of python module; string type;
-      url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/hard_sample_mining.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/hard_sample_mining.py"
       hyperparameters:
         - threhold:
             values:

--- a/examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/sam_vit_algorithm.yaml
+++ b/examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/sam_vit_algorithm.yaml
@@ -12,8 +12,6 @@ algorithm:
     # the method of splitting dataset; string type; optional;
     # currently the options of value are as follows:
     #   1> "default": the dataset is evenly divided based train_ratio;
-    #splitting_method: "default"
-    #splitting_method: "fwt_splitting"
     splitting_method: "hard-example_splitting"
 
   # algorithm module configuration in the paradigm; list type;
@@ -26,7 +24,7 @@ algorithm:
       # example: basemodel.py has BaseModel module that the alias is "FPN" for this benchmarking;
       name: "BaseModel"
       # the url address of python module; string type;
-      url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/basemodel-vit-sam.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/basemodel-vit-sam.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -41,7 +39,7 @@ algorithm:
       # name of python module; string type;
       name: "TaskDefinitionByOrigin"
       # the url address of python module; string type;
-      url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/task_definition_by_origin-simple.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/task_definition_by_origin-simple.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -54,7 +52,7 @@ algorithm:
       # name of python module; string type;
       name: "TaskAllocationByOrigin"
       # the url address of python module; string type;
-      url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/task_allocation_by_origin-simple.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/task_allocation_by_origin-simple.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -67,7 +65,7 @@ algorithm:
       # name of python module; string type;
       name: "HardSampleMining"
       # the url address of python module; string type;
-      url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/hard_sample_mining.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/hard_sample_mining.py"
       hyperparameters:
         - threhold:
             values:

--- a/examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/vit_algorithm.yaml
+++ b/examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/vit_algorithm.yaml
@@ -12,8 +12,6 @@ algorithm:
     # the method of splitting dataset; string type; optional;
     # currently the options of value are as follows:
     #   1> "default": the dataset is evenly divided based train_ratio;
-    #splitting_method: "default"
-    #splitting_method: "fwt_splitting"
     splitting_method: "hard-example_splitting"
 
   # algorithm module configuration in the paradigm; list type;
@@ -26,7 +24,7 @@ algorithm:
       # example: basemodel.py has BaseModel module that the alias is "FPN" for this benchmarking;
       name: "BaseModel"
       # the url address of python module; string type;
-      url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/basemodel-vit-simple.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/basemodel-vit-simple.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -41,7 +39,7 @@ algorithm:
       # name of python module; string type;
       name: "TaskDefinitionByOrigin"
       # the url address of python module; string type;
-      url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/task_definition_by_origin-simple.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/task_definition_by_origin-simple.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -54,7 +52,7 @@ algorithm:
       # name of python module; string type;
       name: "TaskAllocationByOrigin"
       # the url address of python module; string type;
-      url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/task_allocation_by_origin-simple.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/task_allocation_by_origin-simple.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -67,7 +65,7 @@ algorithm:
       # name of python module; string type;
       name: "HardSampleMining"
       # the url address of python module; string type;
-      url: "./examples/robot/lifelong_learning_bench/testalgorithms/rfnet/hard_sample_mining.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/hard_sample_mining.py"
       hyperparameters:
         - threhold:
             values:

--- a/examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/testenv-all.yaml
+++ b/examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/testenv-all.yaml
@@ -2,9 +2,9 @@ testenv:
   # dataset configuration
   dataset:
     # the url address of train dataset index; string type;
-    train_url: "/home/shijing.hu/ianvs/dataset/all-train-index.txt"
+    train_url: "/data/datasets/all-train-index.txt"
     # the url address of test dataset index; string type;
-    test_url: "/home/shijing.hu/ianvs/dataset/all-test-index.txt"
+    test_url: "/data/datasets/all-test-index.txt"
 
   # model eval configuration of incremental learning;
   model_eval:
@@ -13,7 +13,7 @@ testenv:
       # metric name; string type;
       name: "accuracy"
       # the url address of python file
-      url: "./examples/robot/lifelong_learning_bench/testenv/accuracy.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/accuracy.py"
       mode: "no-inference"
 
     # condition of triggering inference model to update
@@ -28,7 +28,7 @@ testenv:
       # metric name; string type;
     - name: "accuracy"
       # the url address of python file
-      url: "./examples/robot/lifelong_learning_bench/testenv/accuracy.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/accuracy.py"
     - name: "samples_transfer_ratio"
 
   # incremental rounds setting; int type; default value is 2;

--- a/examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/testenv-city.yaml
+++ b/examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/testenv-city.yaml
@@ -2,9 +2,9 @@ testenv:
   # dataset configuration
   dataset:
     # the url address of train dataset index; string type;
-    train_url: "/home/shijing.hu/ianvs/dataset/semantic_segmentation_dataset/city-train-index-2.txt"
+    train_url: "/data/datasets/semantic_segmentation_dataset/city-train-index-2.txt"
     # the url address of test dataset index; string type;
-    test_url: "/home/shijing.hu/ianvs/dataset/semantic_segmentation_dataset/city-test-index-2.txt"
+    test_url: "/data/datasets/semantic_segmentation_dataset/city-test-index-2.txt"
 
   # model eval configuration of incremental learning;
   model_eval:
@@ -13,7 +13,7 @@ testenv:
       # metric name; string type;
       name: "accuracy"
       # the url address of python file
-      url: "./examples/robot/lifelong_learning_bench/testenv/accuracy.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/accuracy.py"
       mode: "no-inference"
 
     # condition of triggering inference model to update
@@ -28,7 +28,7 @@ testenv:
       # metric name; string type;
     - name: "accuracy"
       # the url address of python file
-      url: "./examples/robot/lifelong_learning_bench/testenv/accuracy.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/accuracy.py"
     - name: "samples_transfer_ratio"
 
   # incremental rounds setting; int type; default value is 2;

--- a/examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/testenv-robot-small.yaml
+++ b/examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/testenv-robot-small.yaml
@@ -13,8 +13,7 @@ testenv:
       # metric name; string type;
       name: "accuracy"
       # the url address of python file
-      url: "./examples/robot/lifelong_learning_bench/testenv/accuracy.py"
-      #mode: "no-inference"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/accuracy.py"
       mode: "hard-example-mining"
 
     # condition of triggering inference model to update
@@ -29,7 +28,7 @@ testenv:
       # metric name; string type;
     - name: "accuracy"
       # the url address of python file
-      url: "./examples/robot/lifelong_learning_bench/testenv/accuracy.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/accuracy.py"
     - name: "samples_transfer_ratio"
     - name: "task_avg_acc"
     - name: "BWT"

--- a/examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/testenv-robot.yaml
+++ b/examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/testenv-robot.yaml
@@ -13,9 +13,8 @@ testenv:
       # metric name; string type;
       name: "accuracy"
       # the url address of python file
-      url: "./examples/robot/lifelong_learning_bench/testenv/accuracy.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/accuracy.py"
       mode: "no-inference"
-      #mode: "hard-example-mining"
 
     # condition of triggering inference model to update
     # threshold of the condition; types are float/int
@@ -29,7 +28,7 @@ testenv:
       # metric name; string type;
     - name: "accuracy"
       # the url address of python file
-      url: "./examples/robot/lifelong_learning_bench/testenv/accuracy.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/accuracy.py"
     - name: "samples_transfer_ratio"
     - name: "task_avg_acc"
     - name: "BWT"

--- a/examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/testenv.yaml
+++ b/examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/testenv.yaml
@@ -2,9 +2,9 @@ testenv:
   # dataset configuration
   dataset:
     # the url address of train dataset index; string type;
-    train_url: "/home/shijing.hu/ianvs/dataset/robot_dataset/train-index.txt"
+    train_url: "/data/datasets/robot_dataset/train-index.txt"
     # the url address of test dataset index; string type;
-    test_url: "/home/shijing.hu/ianvs/dataset/robot_dataset/test-index.txt"
+    test_url: "/data/datasets/robot_dataset/test-index.txt"
 
   # model eval configuration of incremental learning;
   model_eval:
@@ -13,7 +13,7 @@ testenv:
       # metric name; string type;
       name: "accuracy"
       # the url address of python file
-      url: "./examples/robot/lifelong_learning_bench/testenv/accuracy.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/accuracy.py"
       mode: "no-inference"
 
     # condition of triggering inference model to update
@@ -28,7 +28,7 @@ testenv:
       # metric name; string type;
     - name: "accuracy"
       # the url address of python file
-      url: "./examples/robot/lifelong_learning_bench/testenv/accuracy.py"
+      url: "./examples/robot/lifelong_learning_bench/semantic-segmentation/testenv/accuracy.py"
     - name: "samples_transfer_ratio"
 
   # incremental rounds setting; int type; default value is 2;


### PR DESCRIPTION
**What type of PR is this?**

/kind bug
/kind cleanup

**What this PR does / why we need it**:
This PR resolves path errors and removes hard-coded developer dependencies in the `robot/lifelong_learning_bench/semantic-segmentation` examples. 

Following the directory restructuring in PR #84, many configuration files were moved to the `semantic-segmentation` subdirectory, breaking their internal relative paths. Additionally, several YAML and Python configurations contained developer-specific absolute paths (e.g., `/home/...`), which prevented the example from running in other environments.

This PR:
* Fixes broken internal references by updating them to correct relative paths.
* Replaces hard-coded paths with standard dataset paths (`/data/datasets/`) and relative project paths (`/ianvs/project/`).
* Scrubs out unnecessary, commented-out configuration parameters (like `#workspace`, `#testenv`, `#mode`) to keep the files clean and readable.

**Which issue(s) this PR fixes**:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_
-->
Fixes #76
