### PR TITLE
fix: change my_evaluate to evaluate in lifelong_learning.py

### DIFF
--- a/core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py
+++ b/core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py
@@ -416,8 +416,7 @@ class LifelongLearning(ParadigmBase):
 
         job = self.build_paradigm_job(ParadigmType.LIFELONG_LEARNING.value)
         _, metric_func = get_metric_func(model_metric)
-        edge_task_index, tasks_detail, res = job.my_evaluate(eval_dataset, metrics=metric_func)
-
+        edge_task_index, tasks_detail, res = job.evaluate(eval_dataset, metrics=metric_func)
         del job
 
         return edge_task_index, tasks_detail, res


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:

`my_eval()` calls `job.my_evaluate()` on line 419, but there's no `my_evaluate` method defined anywhere in the project. The similar function `_eval()` creates the same job object using `build_paradigm_job()` and calls `job.evaluate()`, which works fine. So `my_evaluate` is just a typo for `evaluate`.

I kept the 3-value return unpacking as is — the proposed fix in the issue suggests reducing it to 1, but all callers in `run()` (both `no-inference` and `hard-example-mining` modes) unpack 3 values from `my_eval()`, so changing that would break them.

**Which issue(s) this PR fixes**:

Fixes #284