### PR TITLE
feat: enable quantization support for vLLM backend

### DIFF
--- a/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/base_llm.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/base_llm.py
@@ -83,6 +83,7 @@ class BaseLLM:
             - `repetition_penalty`: float, default 1.05. Repetition penalty
             - `max_tokens`: int, default 512. Maximum tokens to generate
             - `use_cache`: bool, default True. Whether to use reponse cache
+            - `quantization`: str, default None. Quantization method (e.g., 'bitsandbytes', 'awq', 'gptq')
         """
 
         self.model_name = kwargs.get("model", None)
@@ -91,7 +92,8 @@ class BaseLLM:
         self.repetition_penalty = kwargs.get("repetition_penalty", 1.05)
         self.max_tokens = kwargs.get("max_tokens", 512)
         self.use_cache = kwargs.get("use_cache", True)
-
+        self.quantization = kwargs.get("quantization", None)
+    
     def inference(self, data):
         """Inference the model
 

--- a/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/vllm_llm.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/vllm_llm.py
@@ -53,16 +53,19 @@ class VllmLLM(BaseLLM):
         model : str
             Hugging Face style model name. Example: `Qwen/Qwen2.5-0.5B-Instruct`
         """
-        self.model = LLM(
-            model=model,
-            trust_remote_code=True,
-            dtype="float16",
-            tensor_parallel_size=self.tensor_parallel_size,
-            gpu_memory_utilization=self.gpu_memory_utilization,
-            max_model_len = 8192
-            #quantization=self.quantization # TODO need to align with vllm API
-        )
-
+        llm_kwargs = {
+            "model": model,
+            "trust_remote_code": True,
+            "dtype": "float16",
+            "tensor_parallel_size": self.tensor_parallel_size,
+            "gpu_memory_utilization": self.gpu_memory_utilization,
+            "max_model_len": 8192
+        }
+        
+        if self.quantization:
+            llm_kwargs["quantization"] = self.quantization
+        
+        self.model = LLM(**llm_kwargs)
         self.sampling_params = SamplingParams(
             temperature=self.temperature,
             top_p=self.top_p,


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

The `quantization` parameter in `vllm_llm.py` was commented out with a TODO (`# TODO need to align with vllm API`). Traced the issue — `BaseLLM._parse_kwargs()` wasn't parsing `quantization` from kwargs, so `self.quantization` stayed undefined.

Fixed both sides:
- Parse `quantization` in `BaseLLM._parse_kwargs()` (defaults to `None`)
- Conditionally pass it to vLLM's `LLM()` only when set, using a dict-based approach instead of hardcoded args

Backward compatible — existing configs without `quantization` work exactly as before. Users who want quantized inference can now add `quantization: bitsandbytes` (or `awq`, `gptq`) to their config and it just works.

Cross-checked with vLLM docs and the PIPL example which already uses quantization in its configs.

**Which issue(s) this PR fixes**:

Fixes #372