### PR TITLE
docs: clarify dataset format configuration for testenv

### DIFF
--- a/docs/user_interface/how-to-config-testenv.md
+++ b/docs/user_interface/how-to-config-testenv.md
@@ -23,10 +23,46 @@ testenv:
 
 ### The configuration of dataset
 
-| Property | Required | Description |
-|----------|----------|-------------|
+|Property|Required|Description|
+|---|---|---|
 |train_url|yes|The url address of train dataset index; Type: string|
 |test_url|yes|The url address of test dataset index; Type: string|
+
+#### Supported Data Formats
+
+The dataset files can be provided in several formats. The supported data formats are **TXT**, **CSV**, **JSON**, and **JSONL**. 
+
+Here is how the data files should be prepared depending on the format:
+
+##### 1. TXT Format
+For TXT format, each line typically represents a single data record or a path to a data file, optionally followed by its corresponding label separated by a space.
+```txt
+/path/to/image1.jpg dog
+/path/to/image2.jpg cat
+```
+
+##### 2. CSV Format
+For CSV format, the file should contain comma-separated values. It usually includes headers, where one column represents the data (or path to data) and another represents the label.
+```csv
+image_path,label
+/path/to/image1.jpg,dog
+/path/to/image2.jpg,cat
+```
+
+##### 3. JSON / JSONL Format
+For JSON format, it can be a JSON array of objects, or JSON Lines (JSONL) where each line is a valid JSON object.
+```json
+[
+  {"image": "/path/to/image1.jpg", "label": "dog"},
+  {"image": "/path/to/image2.jpg", "label": "cat"}
+]
+```
+
+Or JSONL:
+```json
+{"image": "/path/to/image1.jpg", "label": "dog"}
+{"image": "/path/to/image2.jpg", "label": "cat"}
+```
 
 For example:
 

--- a/docs/user_interface/how-to-config-testenv.md
+++ b/docs/user_interface/how-to-config-testenv.md
@@ -13,10 +13,8 @@ For example:
 
 ```yaml
 testenv:
-  # dataset configuration
   dataset:
     ...
-  # metrics configuration for test case's evaluation; list type;
   metrics:
     ...
 ```
@@ -67,11 +65,8 @@ Or JSONL:
 For example:
 
 ```yaml
-# dataset configuration
 dataset:
-  # the url address of train dataset index; string type;
   train_index: "./dataset/mmlu-5-shot/train_data/data.json"
-  # the url address of test dataset index; string type;
   test_index: "./dataset/mmlu-5-shot/test_data/metadata.json"
 ```
 
@@ -101,18 +96,12 @@ You can select multiple metrics in `examples/cloud-edge-collaborative-inference-
 ```yaml
 # testenv.yaml
 testenv:
-  # dataset configuration
   dataset:
-    # the url address of train dataset index; string type;
     train_data: "./dataset/mmlu-5-shot/train_data/data.json"
-    # the url address of test dataset index; string type;
     test_data_info: "./dataset/mmlu-5-shot/test_data/metadata.json"
 
-  # metrics configuration for test case's evaluation; list type;
   metrics:
-      # metric name; string type;
     - name: "Accuracy"
-      # the url address of python file
       url: "./examples/cloud-edge-collaborative-inference-for-llm/testenv/accuracy.py"
 
     - name: "Edge Ratio"


### PR DESCRIPTION
<!-- Thanks for sending a pull request! Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/ianvs/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind documentation

**What this PR does / why we need it**:
This PR adds detailed documentation regarding the supported dataset formats in [docs/user_interface/how-to-config-testenv.md](cci:7://file:///Users/krrishbiswas/Desktop/LFX/ianvs/docs/user_interface/how-to-config-testenv.md:0:0-0:0). It explains the data formats needed for `train_url` and `test_url` inside `testenv.yaml` and provides concrete examples for TXT, CSV, JSON, and JSONL formats so that users can easily prepare their datasets. It also cleans up redundant comments from the configuration examples for better readability.

**Which issue(s) this PR fixes**:
Fixes #110
