### PR TITLE
fix(llm_simple_qa): replace hardcoded paths and fix basemodel compatibility

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -143,3 +143,8 @@ dmypy.json
 .idea/misc.xml
 .idea/workspace.xml
 .idea/vcs.xml
+
+# Local dev artifacts
+venv311/
+workspace/
+sedna/

--- a/examples/llm_simple_qa/benchmarkingjob.yaml
+++ b/examples/llm_simple_qa/benchmarkingjob.yaml
@@ -2,11 +2,11 @@ benchmarkingjob:
   # job name of bechmarking; string type;
   name: "benchmarkingjob"
   # the url address of job workspace that will reserve the output of tests; string type;
-  workspace: "/home/icyfeather/project/ianvs/workspace"
+  workspace: "./workspace"
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;
-  testenv: "./examples/llm/singletask_learning_bench/simple_qa/testenv/testenv.yaml"
+  testenv: "./examples/llm_simple_qa/testenv/testenv.yaml"
 
   # the configuration of test object
   test_object:
@@ -19,7 +19,7 @@ benchmarkingjob:
       - name: "simple_qa_singletask_learning"
         # the url address of test algorithm configuration file; string type;
         # the file format supports yaml/yml;
-        url: "./examples/llm/singletask_learning_bench/simple_qa/testalgorithms/gen/gen_algorithm.yaml"
+        url: "./examples/llm_simple_qa/testalgorithms/gen/gen_algorithm.yaml"
 
   # the configuration of ranking leaderboard
   rank:

--- a/examples/llm_simple_qa/testalgorithms/gen/basemodel.py
+++ b/examples/llm_simple_qa/testalgorithms/gen/basemodel.py
@@ -27,8 +27,7 @@ from sedna.common.class_factory import ClassType, ClassFactory
 
 from transformers import AutoModelForCausalLM, AutoTokenizer
 import torch
-device = "mps" if torch.backends.mps.is_available() else "cpu"
-
+device = "cuda" if torch.cuda.is_available() else "mps" if torch.backends.mps.is_available() else "cpu"
 
 logging.disable(logging.WARNING)
 

--- a/examples/llm_simple_qa/testalgorithms/gen/basemodel.py
+++ b/examples/llm_simple_qa/testalgorithms/gen/basemodel.py
@@ -47,7 +47,7 @@ class BaseModel:
         )
         self.tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-0.5B-Instruct")
 
-    def preprocess(self, data, **kwargs):
+    def preprocess(self, data=None, **kwargs):
         print("BaseModel doesn't need to preprocess")
         return data
 

--- a/examples/llm_simple_qa/testalgorithms/gen/basemodel.py
+++ b/examples/llm_simple_qa/testalgorithms/gen/basemodel.py
@@ -48,9 +48,9 @@ class BaseModel:
         )
         self.tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-0.5B-Instruct")
 
-    def preprocess(self, **kwargs):
+    def preprocess(self, data, **kwargs):
         print("BaseModel doesn't need to preprocess")
-        return None
+        return data
 
     def train(self, train_data, valid_data=None, **kwargs):
         print("BaseModel doesn't need to train")

--- a/examples/llm_simple_qa/testalgorithms/gen/basemodel.py
+++ b/examples/llm_simple_qa/testalgorithms/gen/basemodel.py
@@ -26,7 +26,8 @@ from sedna.common.class_factory import ClassType, ClassFactory
 
 
 from transformers import AutoModelForCausalLM, AutoTokenizer
-device = "cuda" # the device to load the model onto
+import torch
+device = "mps" if torch.backends.mps.is_available() else "cpu"
 
 
 logging.disable(logging.WARNING)
@@ -41,11 +42,15 @@ class BaseModel:
 
     def __init__(self, **kwargs):
         self.model = AutoModelForCausalLM.from_pretrained(
-            "/home/icyfeather/models/Qwen2-0.5B-Instruct",
+            "Qwen/Qwen2.5-0.5B-Instruct",
             torch_dtype="auto",
             device_map="auto"
         )
-        self.tokenizer = AutoTokenizer.from_pretrained("/home/icyfeather/models/Qwen2-0.5B-Instruct")
+        self.tokenizer = AutoTokenizer.from_pretrained("Qwen/Qwen2.5-0.5B-Instruct")
+
+    def preprocess(self, **kwargs):
+        print("BaseModel doesn't need to preprocess")
+        return None
 
     def train(self, train_data, valid_data=None, **kwargs):
         print("BaseModel doesn't need to train")

--- a/examples/llm_simple_qa/testalgorithms/gen/gen_algorithm.yaml
+++ b/examples/llm_simple_qa/testalgorithms/gen/gen_algorithm.yaml
@@ -15,4 +15,4 @@ algorithm:
       # example: basemodel.py has BaseModel module that the alias is "FPN" for this benchmarking;
       name: "gen"
       # the url address of python module; string type;
-      url: "./examples/llm/singletask_learning_bench/simple_qa/testalgorithms/gen/basemodel.py"
+      url: "./examples/llm_simple_qa/testalgorithms/gen/basemodel.py"

--- a/examples/llm_simple_qa/testenv/testenv.yaml
+++ b/examples/llm_simple_qa/testenv/testenv.yaml
@@ -2,13 +2,13 @@ testenv:
   # dataset configuration
   dataset:
     # the url address of train dataset index; string type;
-    train_data: "/home/icyfeather/Projects/ianvs/dataset/llm_simple_qa/train_data/data.jsonl"
+    train_data: "./dataset/llm_simple_qa/train_data/data.jsonl"
     # the url address of test dataset index; string type;
-    test_data: "/home/icyfeather/Projects/ianvs/dataset/llm_simple_qa/test_data/data.jsonl"
+    test_data: "./dataset/llm_simple_qa/test_data/data.jsonl"
 
   # metrics configuration for test case's evaluation; list type;
   metrics:
       # metric name; string type;
     - name: "acc"
       # the url address of python file
-      url: "./examples/llm/singletask_learning_bench/simple_qa/testenv/acc.py"
+      url: "./examples/llm_simple_qa/testenv/acc.py"


### PR DESCRIPTION
## What this PR does

Fixes the `llm_simple_qa` example which was broken due to hardcoded paths and missing methods. 
Fixes #387 

### Changes
- **YAML configs**: Replaced all hardcoded absolute paths (`/home/icyfeather/...`) with relative paths (`./examples/...`, `./dataset/...`, `./workspace`)
- **basemodel.py**: 
  - Use HuggingFace Hub model ID (`Qwen/Qwen2.5-0.5B-Instruct`) instead of local path
  - Added missing `preprocess()` method required by sedna's SingleTaskLearning paradigm
  - Added MPS/CPU device detection for cross-platform compatibility

### Testing
Verified the benchmark runs end-to-end successfully:

```
$ ianvs -f examples/llm_simple_qa/benchmarkingjob.yaml

Loading weights: 100%|████████████████████| 290/290 [00:01<00:00, 250.13it/s]
BaseModel doesn't need to preprocess
BaseModel doesn't need to train
BaseModel doesn't need to save
BaseModel load
BaseModel predict
+------+-------------------------------+-----+--------------------+-----------+---------------------+
| rank |           algorithm           | acc |      paradigm      | basemodel |         time        |
+------+-------------------------------+-----+--------------------+-----------+---------------------+
|  1   | simple_qa_singletask_learning | 0.8 | singletasklearning |    gen    | 2026-04-12 05:26:45 |
+------+-------------------------------+-----+--------------------+-----------+---------------------+
```
