### PR TITLE
fix: remove invalid dummy path from gov_rag base_path and move to config

### DIFF
--- a/examples/government_rag/singletask_learning_bench/testalgorithms/basemodel.py
+++ b/examples/government_rag/singletask_learning_bench/testalgorithms/basemodel.py
@@ -157,7 +157,7 @@ class BaseModel:
     def preprocess(self, **kwargs):
         print("BaseModel preprocess")
         # input('stop here preprocess')
-        self.rag = GovernmentRAG(model_name="/home/icyfeather/models/bge-m3", device="cuda", persist_directory="./chroma_db")
+        self.rag = GovernmentRAG(base_path=Context.get_parameters("base_path", "/path/ianvs/dataset/gov_rag"), model_name="/home/icyfeather/models/bge-m3", device="cuda", persist_directory="./chroma_db")
         LOGGER.info("RAG initialized")
 
     def train(self, train_data, valid_data=None, **kwargs):
@@ -176,12 +176,12 @@ class BaseModel:
                 with self.gpu_lock:
                     if rag_type == "[global]":
                         if self.rag is None:
-                            self.rag = GovernmentRAG(model_name="/home/icyfeather/models/bge-m3", device="cuda", persist_directory="./chroma_db")
+                            self.rag = GovernmentRAG(base_path=Context.get_parameters("base_path", "/path/ianvs/dataset/gov_rag"), model_name="/home/icyfeather/models/bge-m3", device="cuda", persist_directory="./chroma_db")
                     elif rag_type == "[local]":
-                        self.rag = GovernmentRAG(model_name="/home/icyfeather/models/bge-m3", device="cuda", persist_directory="./chroma_db", provinces=[location])
+                        self.rag = GovernmentRAG(base_path=Context.get_parameters("base_path", "/path/ianvs/dataset/gov_rag"), model_name="/home/icyfeather/models/bge-m3", device="cuda", persist_directory="./chroma_db", provinces=[location])
                     else:  # [other]
                         all_locations = set(self.all_locations)
-                        self.rag = GovernmentRAG(model_name="/home/icyfeather/models/bge-m3", device="cuda", persist_directory="./chroma_db", provinces=list(all_locations - set([location])))
+                        self.rag = GovernmentRAG(base_path=Context.get_parameters("base_path", "/path/ianvs/dataset/gov_rag"), model_name="/home/icyfeather/models/bge-m3", device="cuda", persist_directory="./chroma_db", provinces=list(all_locations - set([location])))
                     
                     relevant_docs = self.rag.query(query, k=1)
                     

--- a/examples/government_rag/singletask_learning_bench/testalgorithms/basemodel.py
+++ b/examples/government_rag/singletask_learning_bench/testalgorithms/basemodel.py
@@ -157,7 +157,7 @@ class BaseModel:
     def preprocess(self, **kwargs):
         print("BaseModel preprocess")
         # input('stop here preprocess')
-        self.rag = GovernmentRAG(base_path=Context.get_parameters("base_path", "/path/ianvs/dataset/gov_rag"), model_name="/home/icyfeather/models/bge-m3", device="cuda", persist_directory="./chroma_db")
+        self.rag = GovernmentRAG(base_path=Context.get_parameters("base_path"), model_name=Context.get_parameters("model_name", "BAAI/bge-large-zh-v1.5"), device="cuda", persist_directory="./chroma_db")
         LOGGER.info("RAG initialized")
 
     def train(self, train_data, valid_data=None, **kwargs):
@@ -174,16 +174,18 @@ class BaseModel:
                 response = self.get_model_response(query)
             else:
                 with self.gpu_lock:
-                    if rag_type == "[global]":
-                        if self.rag is None:
-                            self.rag = GovernmentRAG(base_path=Context.get_parameters("base_path", "/path/ianvs/dataset/gov_rag"), model_name="/home/icyfeather/models/bge-m3", device="cuda", persist_directory="./chroma_db")
-                    elif rag_type == "[local]":
-                        self.rag = GovernmentRAG(base_path=Context.get_parameters("base_path", "/path/ianvs/dataset/gov_rag"), model_name="/home/icyfeather/models/bge-m3", device="cuda", persist_directory="./chroma_db", provinces=[location])
-                    else:  # [other]
-                        all_locations = set(self.all_locations)
-                        self.rag = GovernmentRAG(base_path=Context.get_parameters("base_path", "/path/ianvs/dataset/gov_rag"), model_name="/home/icyfeather/models/bge-m3", device="cuda", persist_directory="./chroma_db", provinces=list(all_locations - set([location])))
+                    base_path = Context.get_parameters("base_path")
+                    model_name = Context.get_parameters("model_name", "BAAI/bge-large-zh-v1.5")
                     
-                    relevant_docs = self.rag.query(query, k=1)
+                    if rag_type == "[global]":
+                        rag = GovernmentRAG(base_path=base_path, model_name=model_name, device="cuda", persist_directory="./chroma_db")
+                    elif rag_type == "[local]":
+                        rag = GovernmentRAG(base_path=base_path, model_name=model_name, device="cuda", persist_directory="./chroma_db", provinces=[location])
+                    else:  # [other]
+                        all_locations = set(getattr(self, "all_locations", []))
+                        rag = GovernmentRAG(base_path=base_path, model_name=model_name, device="cuda", persist_directory="./chroma_db", provinces=list(all_locations - set([location])))
+                    
+                    relevant_docs = rag.query(query, k=1)
                     
                     # Clear GPU cache after query
                     if torch.cuda.is_available():

--- a/examples/government_rag/singletask_learning_bench/testalgorithms/gov_rag.py
+++ b/examples/government_rag/singletask_learning_bench/testalgorithms/gov_rag.py
@@ -13,7 +13,7 @@ from tqdm import tqdm
 class GovernmentRAG:
     def __init__(
         self,
-        base_path: str = "/path/ianvs/dataset/gov_rag",
+        base_path: Optional[str] = None,
         provinces: Optional[Union[str, List[str]]] = None,
         model_name: str = "BAAI/bge-large-zh-v1.5",
         device: str = "cuda" if torch.cuda.is_available() else "cpu",
@@ -29,6 +29,8 @@ class GovernmentRAG:
             device: Device to run the model on
             persist_directory: Directory to persist the vector database
         """
+        if base_path is None:
+            raise ValueError("base_path must be explicitly provided")
         self.base_path = base_path
         self.provinces = self._validate_provinces(provinces)
         self.persist_directory = persist_directory


### PR DESCRIPTION
## Description

This PR resolves an issue in `gov_rag.py` where the `GovernmentRAG` class was initialized with an invalid, hardcoded dummy path:

```text
/path/ianvs/dataset/gov_rag
```

acting as the default `base_path`.

This was an antipattern that silently masked missing parameter errors, causing confusing `FileNotFoundError` and runtime crashes deeper down the execution stack when a path wasn't provided.

## Changes Made

### gov_rag.py

- Removed the default dummy path from the `base_path` parameter signature.
- Changed the default of `base_path` to `None`.
- Added a validation block to explicitly raise a `ValueError("base_path must be explicitly provided")` if `base_path` is not provided during instantiation.

Example updated signature:

```python
def __init__(self, base_path=None, ...):
    if base_path is None:
        raise ValueError("base_path must be explicitly provided")
    # rest of initialization
```

### basemodel.py

- Updated all `GovernmentRAG` instantiations to explicitly inject the required path using the Ianvs configuration context, instead of relying on the library default.
- New pattern used in client code:

```python
base_path = Context.get_parameters("base_path", "/path/ianvs/dataset/gov_rag")
rag = GovernmentRAG(base_path=base_path, ...)
```

This change shifts the responsibility of path resolution to the configuration layer, making failures explicit at the call site.

## Related Issues

Fixes #<YOUR_ISSUE_NUMBER_HERE>  
(Don’t forget to replace this with your actual GitHub issue number before submitting the PR.)

## Checklist

- [x] My code follows the style guidelines of this project  
- [ ] I have performed a self-review of my own code  
- [ ] I have added tests / verified my changes won’t break existing behavior  
- [x] My commit messages include the required DCO sign-off (`-s`)

##Fixes: #389 