### PR TITLE
fix: update stale pedestrian_tracking paths to fix broken examples

### DIFF
--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/README.md
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/README.md
@@ -98,7 +98,7 @@ python ./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/generate_r
 -r ./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/reid_job.yaml
 ```
 
-Finally, the report is generated under <Ianvs_HOME>/examples/pedestrian_tracking/multiedge_inference_bench/reports. You can also check the sample report under the current directory.
+Finally, the report is generated under <Ianvs_HOME>/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/reports. You can also check the sample report under the current directory.
 
 ## What is next
 

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/generate_reports.py
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/generate_reports.py
@@ -90,7 +90,7 @@ def main():
         reid_result = reid_rank.sort_values(by="time", ascending=False).iloc[0]
         pdf = PDF()
         pdf.print_page([tracking_result, reid_result])
-        output_dir = Path("./examples/pedestrian_tracking/multiedge_inference_bench/reports")
+        output_dir = Path(__file__).resolve().parent / "reports"
         output_dir.mkdir(parents=True, exist_ok=True)
         pdf.output(Path(output_dir, datetime.datetime.now().strftime("%Y%m%d%H%M%S") + ".pdf"), "F")
     except Exception as err:

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/reid_job.yaml
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/reid_job.yaml
@@ -6,7 +6,7 @@ benchmarkingjob:
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;
-  testenv: "./examples/pedestrian_tracking/multiedge_inference_bench/testenv/reid/testenv.yaml"
+  testenv: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/reid/testenv.yaml"
 
   # the configuration of test object
   test_object:
@@ -19,7 +19,7 @@ benchmarkingjob:
       - name: "feature extraction"
         # the url address of test algorithm configuration file; string type;
         # the file format supports yaml/yml;
-        url: "./examples/pedestrian_tracking/multiedge_inference_bench/testalgorithms/reid/m3l/m3l_algorithm.yaml"
+        url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testalgorithms/reid/m3l/m3l_algorithm.yaml"
 
   # the configuration of ranking leaderboard
   rank:

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testalgorithms/reid/m3l/m3l_algorithm.yaml
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testalgorithms/reid/m3l/m3l_algorithm.yaml
@@ -17,7 +17,7 @@ algorithm:
       # example: basemodel.py has BaseModel module that the alias is "FPN" for this benchmarking;
       name: "M3L"
       # the url address of python module; string type;
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testalgorithms/reid/m3l/basemodel.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testalgorithms/reid/m3l/basemodel.py"
 
       # hyperparameters configuration for the python module; list type;
       hyperparameters:

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testalgorithms/tracking/byte_track/byte_track_algorithm.yaml
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testalgorithms/tracking/byte_track/byte_track_algorithm.yaml
@@ -17,7 +17,7 @@ algorithm:
       # example: basemodel.py has BaseModel module that the alias is "FPN" for this benchmarking;
       name: "ByteTrack"
       # the url address of python module; string type;
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testalgorithms/tracking/byte_track/basemodel.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testalgorithms/tracking/byte_track/basemodel.py"
 
       # hyperparameters configuration for the python module; list type;
       hyperparameters:

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/reid/cmc.py
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/reid/cmc.py
@@ -45,7 +45,7 @@ def plot_cmc(distmat, query_ids, gallery_ids, topk):
     cmc.yaxis.set_major_formatter(mtick.PercentFormatter(1.00))
     cmc.set(xlim=(0, topk), ylim=(0, 1))
     fig = cmc.get_figure()
-    output_dir = Path("./examples/pedestrian_tracking/multiedge_inference_bench/cmc")
+    output_dir = Path(__file__).resolve().parents[2] / "cmc"
     output_dir.mkdir(parents=True, exist_ok=True)
     output_file = Path(output_dir, datetime.datetime.now().strftime("%Y%m%d%H%M%S") + ".png")
     fig.savefig(output_file)

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/reid/testenv.yaml
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/reid/testenv.yaml
@@ -11,16 +11,16 @@ testenv:
       # metric name; string type;
     - name: "mAP"
       # the url address of python file
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testenv/reid/mAP.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/reid/mAP.py"
     - name: "rank_1"
       # the url address of python file
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testenv/reid/rank_1.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/reid/rank_1.py"
     - name: "rank_2"
       # the url address of python file
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testenv/reid/rank_2.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/reid/rank_2.py"
     - name: "rank_5"
       # the url address of python file
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testenv/reid/rank_5.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/reid/rank_5.py"
     - name: "cmc"
       # the url address of python file
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testenv/reid/cmc.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/reid/cmc.py"

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/testenv.yaml
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/testenv.yaml
@@ -11,19 +11,19 @@ testenv:
       # metric name; string type;
     - name: "recall"
       # the url address of python file
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testenv/tracking/recall.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/recall.py"
     - name: "precision"
       # the url address of python file
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testenv/tracking/precision.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/precision.py"
     - name: "f1_score"
       # the url address of python file
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testenv/tracking/f1_score.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/f1_score.py"
     - name: "mota"
       # the url address of python file
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testenv/tracking/mota.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/mota.py"
     - name: "motp"
       # the url address of python file
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testenv/tracking/motp.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/motp.py"
     - name: "idf1"
       # the url address of python file
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testenv/tracking/idf1.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/idf1.py"

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/tracking_job.yaml
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/tracking_job.yaml
@@ -6,7 +6,7 @@ benchmarkingjob:
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;
-  testenv: "./examples/pedestrian_tracking/multiedge_inference_bench/testenv/tracking/testenv.yaml"
+  testenv: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/testenv.yaml"
 
   # the configuration of test object
   test_object:
@@ -19,7 +19,7 @@ benchmarkingjob:
       - name: "tracking"
       #   # the url address of test algorithm configuration file; string type;
       #   # the file format supports yaml/yml;
-        url: "./examples/pedestrian_tracking/multiedge_inference_bench/testalgorithms/tracking/byte_track/byte_track_algorithm.yaml"
+        url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testalgorithms/tracking/byte_track/byte_track_algorithm.yaml"
 
   # the configuration of ranking leaderboard
   rank:


### PR DESCRIPTION
## What does this PR do?

This PR fixes a critical pathing issue in the MOT17 benchmark example that was preventing it from running. It appears the example directory was previously renamed from `pedestrian_tracking` to `MOT17`, but the internal file references within the `.yaml` configs and `.py` files were never updated.

This PR performs a global replacement of:

```text
./examples/pedestrian_tracking/
```

to:

```text
./examples/MOT17/
```

across all affected configuration files and scripts.

## Why is it needed?

Currently, running:

```bash
ianvs -f ./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/tracking_job.yaml
```

(or the `reid_job.yaml`) fails immediately with a `FileNotFoundError`, because Ianvs attempts to resolve the `testenv`, algorithm, and metric scripts at the old path.

Resolving these paths restores the out‑of‑the‑box functionality of the MOT17 benchmarking examples, allowing both tracking and ReID jobs to run without path errors.

## Changes proposed

Replaced the stale path `pedestrian_tracking/multiedge_inference_bench` with `MOT17/multiedge_inference_bench/pedestrian_tracking` in the following files:

### Configs
- `tracking_job.yaml`  
- `reid_job.yaml`

### Algorithms
- `m3l_algorithm.yaml`  
- `byte_track_algorithm.yaml`

### Test Environments
- `testenv/reid/testenv.yaml`  
- `testenv/tracking/testenv.yaml`

### Python Scripts
- `generate_reports.py` (fixed hardcoded output directory path)  
- `testenv/reid/cmc.py` (fixed hardcoded output directory path)

### Docs
- `README.md` (updated example path in the report generation documentation)

## Testing done

- Conducted a code audit and static verification to ensure all `pedestrian_tracking` references relating to the old root path were replaced.
- Verified that all paths now point to existing files in the current repository structure.
- Confirmed that benchmark jobs for both tracking and ReID now resolve configs and scripts without `FileNotFoundError` when executed from the root directory.

##Fixes: #391