### PR TITLE
cleanup: introduce EnvKey constants for all ianvs environment variables

### DIFF
--- a/core/common/constant.py
+++ b/core/common/constant.py
@@ -103,7 +103,7 @@ class TestObjectType(Enum):
     ALGORITHMS = "algorithms"
 
 
-class EnvKey:
+class EnvKey(str, Enum):
     """
     Canonical names of the environment variables that ianvs sets for algorithm modules.
 

--- a/core/common/constant.py
+++ b/core/common/constant.py
@@ -101,3 +101,49 @@ class TestObjectType(Enum):
     """
 
     ALGORITHMS = "algorithms"
+
+
+class EnvKey:
+    """
+    Canonical names of the environment variables that ianvs sets for algorithm modules.
+
+    Using these constants instead of inline strings eliminates typos, provides a single
+    authoritative reference, and makes the YAML-key → env-var mapping explicit.
+
+    Mapping to the YAML ``algorithm`` config key:
+        ``initial_model_url``  →  :attr:`BASE_MODEL_URL`
+    """
+
+    # Path to the starting model supplied via ``initial_model_url`` in the algorithm YAML.
+    # Algorithm train() implementations should read this to locate the base checkpoint.
+    BASE_MODEL_URL = "BASE_MODEL_URL"
+
+    # Output path where the algorithm should write the newly trained model.
+    MODEL_URL = "MODEL_URL"
+
+    # Semicolon-separated list of model paths used during evaluation and lifelong learning.
+    MODEL_URLS = "MODEL_URLS"
+
+    # Base output directory for the current paradigm step (train / eval / inference).
+    OUTPUT_URL = "OUTPUT_URL"
+
+    # Directory where inference result files should be written.
+    RESULT_SAVED_URL = "RESULT_SAVED_URL"
+
+    # Directory for per-sample inference result files in lifelong learning.
+    INFERENCE_RESULT_DIR = "INFERENCE_RESULT_DIR"
+
+    # Path to the cloud knowledge-base task index used in lifelong learning.
+    CLOUD_KB_INDEX = "CLOUD_KB_INDEX"
+
+    # "True" / "False" string: whether the initial training round has completed.
+    HAS_COMPLETED_INITIAL_TRAINING = "HAS_COMPLETED_INITIAL_TRAINING"
+
+    # Floating-point threshold (as a string) for model-update trigger decisions.
+    MODEL_THRESHOLD = "model_threshold"
+
+    # Comparison operator string (">", "<", ">=", …) for model-update trigger decisions.
+    OPERATOR = "operator"
+
+    # Set to "TRUE" when ianvs runs a local (non-Kubernetes) benchmark.
+    LOCAL_TEST = "LOCAL_TEST"

--- a/core/testcasecontroller/algorithm/paradigm/base.py
+++ b/core/testcasecontroller/algorithm/paradigm/base.py
@@ -19,7 +19,7 @@ import os
 from sedna.core.incremental_learning import IncrementalLearning
 from sedna.core.lifelong_learning import LifelongLearning
 from sedna.core.joint_inference import JointInference
-from core.common.constant import ModuleType, ParadigmType
+from core.common.constant import EnvKey, ModuleType, ParadigmType
 from .sedna_federated_learning import FederatedLearning
 
 
@@ -54,7 +54,7 @@ class ParadigmBase:
         self.workspace = workspace
         self.system_metric_info = {}
         self.module_instances = self._get_module_instances()
-        os.environ["LOCAL_TEST"] = "TRUE"
+        os.environ[EnvKey.LOCAL_TEST] = "TRUE"
 
     def dataset_output_dir(self):
         """

--- a/core/testcasecontroller/algorithm/paradigm/incremental_learning/incremental_learning.py
+++ b/core/testcasecontroller/algorithm/paradigm/incremental_learning/incremental_learning.py
@@ -20,7 +20,7 @@ import tempfile
 
 import numpy as np
 
-from core.common.constant import ParadigmType, SystemMetricType
+from core.common.constant import EnvKey, ParadigmType, SystemMetricType
 from core.testcasecontroller.algorithm.paradigm.base import ParadigmBase
 from core.testcasecontroller.metrics import get_metric_func
 from core.common.utils import get_file_format, is_local_dir
@@ -121,8 +121,8 @@ class IncrementalLearning(ParadigmBase):
         if not is_local_dir(hard_example_saved_dir):
             os.makedirs(hard_example_saved_dir)
 
-        os.environ["RESULT_SAVED_URL"] = inference_output_dir
-        os.environ["MODEL_URL"] = model
+        os.environ[EnvKey.RESULT_SAVED_URL] = inference_output_dir
+        os.environ[EnvKey.MODEL_URL] = model
 
         return hard_example_saved_dir
 
@@ -166,8 +166,8 @@ class IncrementalLearning(ParadigmBase):
         if not is_local_dir(train_output_dir):
             os.makedirs(train_output_dir)
 
-        os.environ["MODEL_URL"] = train_output_dir
-        os.environ["BASE_MODEL_URL"] = model
+        os.environ[EnvKey.MODEL_URL] = train_output_dir
+        os.environ[EnvKey.BASE_MODEL_URL] = model
 
         job = self.build_paradigm_job(ParadigmType.INCREMENTAL_LEARNING.value)
         train_dataset = self.dataset.load_data(data_index_file, "train")
@@ -177,7 +177,7 @@ class IncrementalLearning(ParadigmBase):
         return new_model
 
     def _eval(self, new_model, old_model, data_index_file):
-        os.environ["MODEL_URLS"] = f"{new_model};{old_model}"
+        os.environ[EnvKey.MODEL_URLS] = f"{new_model};{old_model}"
         model_eval_info = self.model_eval_config
         model_metric = model_eval_info.get("model_metric")
 

--- a/core/testcasecontroller/algorithm/paradigm/joint_inference/joint_inference.py
+++ b/core/testcasecontroller/algorithm/paradigm/joint_inference/joint_inference.py
@@ -18,7 +18,7 @@ import os
 from tqdm import tqdm
 
 from core.common.log import LOGGER
-from core.common.constant import ParadigmType
+from core.common.constant import EnvKey, ParadigmType
 from core.testcasecontroller.algorithm.paradigm.base import ParadigmBase
 
 class JointInference(ParadigmBase):
@@ -67,7 +67,7 @@ class JointInference(ParadigmBase):
 
 
         inference_output_dir = os.path.dirname(self.workspace)
-        os.environ["RESULT_SAVED_URL"] = inference_output_dir
+        os.environ[EnvKey.RESULT_SAVED_URL] = inference_output_dir
         os.makedirs(inference_output_dir, exist_ok=True)
 
         LOGGER.info("Loading dataset")

--- a/core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py
+++ b/core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py
@@ -19,8 +19,7 @@ import shutil
 import numpy as np
 from sedna.datasources import BaseDataSource
 from core.common.log import LOGGER
-from core.common.constant import ParadigmType, SystemMetricType
-from core.common.constant import EnvKey
+from core.common.constant import EnvKey, ParadigmType, SystemMetricType
 from core.testcasecontroller.algorithm.paradigm.base import ParadigmBase
 from core.testcasecontroller.metrics import get_metric_func
 from core.common.utils import get_file_format, is_local_dir

--- a/core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py
+++ b/core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py
@@ -354,7 +354,7 @@ class LifelongLearning(ParadigmBase):
         if not is_local_dir(train_output_dir):
             os.makedirs(train_output_dir)
 
-        os.environ[EnvKey.CLOUD_KB_INDEX] = cloud_task_index
+        os.environ[EnvKey.CLOUD_KB_INDEX] = str(cloud_task_index)
         os.environ[EnvKey.OUTPUT_URL] = train_output_dir
         if rounds < 1:
             os.environ[EnvKey.HAS_COMPLETED_INITIAL_TRAINING] = 'False'

--- a/core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py
+++ b/core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py
@@ -20,6 +20,7 @@ import numpy as np
 from sedna.datasources import BaseDataSource
 from core.common.log import LOGGER
 from core.common.constant import ParadigmType, SystemMetricType
+from core.common.constant import EnvKey
 from core.testcasecontroller.algorithm.paradigm.base import ParadigmBase
 from core.testcasecontroller.metrics import get_metric_func
 from core.common.utils import get_file_format, is_local_dir
@@ -311,9 +312,9 @@ class LifelongLearning(ParadigmBase):
         if not is_local_dir(unseen_task_saved_dir):
             os.makedirs(unseen_task_saved_dir)
 
-        os.environ["INFERENCE_RESULT_DIR"] = output_dir
-        os.environ["OUTPUT_URL"] = output_dir
-        os.environ["MODEL_URLS"] = f"{edge_task_index}"
+        os.environ[EnvKey.INFERENCE_RESULT_DIR] = output_dir
+        os.environ[EnvKey.OUTPUT_URL] = output_dir
+        os.environ[EnvKey.MODEL_URLS] = f"{edge_task_index}"
 
         inference_dataset = self.dataset.load_data(data_index_file, "eval",
                                                    feature_process=_data_feature_process)
@@ -354,12 +355,12 @@ class LifelongLearning(ParadigmBase):
         if not is_local_dir(train_output_dir):
             os.makedirs(train_output_dir)
 
-        os.environ["CLOUD_KB_INDEX"] = cloud_task_index
-        os.environ["OUTPUT_URL"] = train_output_dir
+        os.environ[EnvKey.CLOUD_KB_INDEX] = cloud_task_index
+        os.environ[EnvKey.OUTPUT_URL] = train_output_dir
         if rounds < 1:
-            os.environ["HAS_COMPLETED_INITIAL_TRAINING"] = 'False'
+            os.environ[EnvKey.HAS_COMPLETED_INITIAL_TRAINING] = 'False'
         else:
-            os.environ["HAS_COMPLETED_INITIAL_TRAINING"] = 'True'
+            os.environ[EnvKey.HAS_COMPLETED_INITIAL_TRAINING] = 'True'
 
         if isinstance(train_dataset, str):
             train_dataset = self.dataset.load_data(train_dataset, "train",
@@ -379,10 +380,10 @@ class LifelongLearning(ParadigmBase):
         model_eval_info = self.model_eval_config
         model_metric = model_eval_info.get("model_metric")
 
-        os.environ["OUTPUT_URL"] = eval_output_dir
-        os.environ["model_threshold"] = str(model_eval_info.get("threshold"))
-        os.environ["operator"] = model_eval_info.get("operator")
-        os.environ["MODEL_URLS"] = f"{cloud_task_index}"
+        os.environ[EnvKey.OUTPUT_URL] = eval_output_dir
+        os.environ[EnvKey.MODEL_THRESHOLD] = str(model_eval_info.get("threshold"))
+        os.environ[EnvKey.OPERATOR] = model_eval_info.get("operator")
+        os.environ[EnvKey.MODEL_URLS] = f"{cloud_task_index}"
 
         eval_dataset = self.dataset.load_data(data_index_file, "eval",
                                               feature_process=_data_feature_process)
@@ -406,10 +407,10 @@ class LifelongLearning(ParadigmBase):
         model_eval_info = self.model_eval_config
         model_metric = model_eval_info.get("model_metric")
 
-        os.environ["OUTPUT_URL"] = eval_output_dir
-        os.environ["model_threshold"] = str(model_eval_info.get("threshold"))
-        os.environ["operator"] = model_eval_info.get("operator")
-        os.environ["MODEL_URLS"] = f"{cloud_task_index}"
+        os.environ[EnvKey.OUTPUT_URL] = eval_output_dir
+        os.environ[EnvKey.MODEL_THRESHOLD] = str(model_eval_info.get("threshold"))
+        os.environ[EnvKey.OPERATOR] = model_eval_info.get("operator")
+        os.environ[EnvKey.MODEL_URLS] = f"{cloud_task_index}"
 
         eval_dataset = self.dataset.load_data(data_index_file, "eval",
                                               feature_process=_data_feature_process)

--- a/core/testcasecontroller/algorithm/paradigm/multiedge_inference/multiedge_inference.py
+++ b/core/testcasecontroller/algorithm/paradigm/multiedge_inference/multiedge_inference.py
@@ -20,7 +20,7 @@ import os
 import onnx
 
 from core.common.log import LOGGER
-from core.common.constant import ParadigmType
+from core.common.constant import EnvKey, ParadigmType
 from core.testcasecontroller.algorithm.paradigm.base import ParadigmBase
 
 
@@ -81,10 +81,10 @@ class MultiedgeInference(ParadigmBase):
 
     def _inference(self, job, trained_model):
         train_dataset = self.dataset.load_data(self.dataset.train_url, "train")
-        os.environ["BASE_MODEL_URL"] = trained_model
+        os.environ[EnvKey.BASE_MODEL_URL] = trained_model
         inference_dataset = self.dataset.load_data(self.dataset.test_url, "inference")
         inference_output_dir = os.path.join(self.workspace, "output/inference/")
-        os.environ["RESULT_SAVED_URL"] = inference_output_dir
+        os.environ[EnvKey.RESULT_SAVED_URL] = inference_output_dir
         job.load(trained_model)
         infer_res = job.predict(inference_dataset.x, train_dataset=train_dataset)
         return infer_res
@@ -92,7 +92,7 @@ class MultiedgeInference(ParadigmBase):
     def _inference_mp(self, job, models_dir, map_info):
         inference_dataset = self.dataset.load_data(self.dataset.test_url, "inference")
         inference_output_dir = os.path.join(self.workspace, "output/inference/")
-        os.environ["RESULT_SAVED_URL"] = inference_output_dir
+        os.environ[EnvKey.RESULT_SAVED_URL] = inference_output_dir
         job.load(models_dir, map_info)
         infer_res = job.predict(inference_dataset.x)
         return infer_res

--- a/core/testcasecontroller/algorithm/paradigm/singletask_learning/singletask_learning.py
+++ b/core/testcasecontroller/algorithm/paradigm/singletask_learning/singletask_learning.py
@@ -16,7 +16,7 @@
 
 import os
 import subprocess
-from core.common.constant import ParadigmType
+from core.common.constant import EnvKey, ParadigmType
 from core.testcasecontroller.algorithm.paradigm.base import ParadigmBase
 
 
@@ -117,7 +117,7 @@ class SingleTaskLearning(ParadigmBase):
 
     def _train(self, job, initial_model):
         train_output_dir = os.path.join(self.workspace, "output/train/")
-        os.environ["BASE_MODEL_URL"] = initial_model
+        os.environ[EnvKey.BASE_MODEL_URL] = initial_model
 
         train_dataset = self.dataset.load_data(self.dataset.train_url, "train")
         job.train(train_dataset)
@@ -127,7 +127,7 @@ class SingleTaskLearning(ParadigmBase):
     def _inference(self, job, trained_model):
         inference_dataset = self.dataset.load_data(self.dataset.test_url, "inference")
         inference_output_dir = os.path.join(self.workspace, "output/inference/")
-        os.environ["RESULT_SAVED_URL"] = inference_output_dir
+        os.environ[EnvKey.RESULT_SAVED_URL] = inference_output_dir
         job.load(trained_model)
         if hasattr(inference_dataset, 'need_other_info'):
             infer_res = job.predict(inference_dataset)


### PR DESCRIPTION
## Summary

- Adds `EnvKey` class to `core/common/constant.py` as a single authoritative source for all environment variable names that ianvs sets for algorithm modules
- Replaces every inline `os.environ["STRING"]` key across all paradigm files (`singletask_learning`, `incremental_learning`, `lifelong_learning`, `multiedge_inference`, `joint_inference`, `base`) with the corresponding `EnvKey.*` constant
- Makes the `initial_model_url` (YAML key) → `BASE_MODEL_URL` (env var) mapping explicit in `EnvKey`'s docstring, resolving the long-standing confusion documented in #14

## Motivation

Prior to this change, the same env var name (e.g. `"BASE_MODEL_URL"`) was copy-pasted as a raw string in multiple files. A single typo would cause a silent runtime failure that is impossible to catch at import time. The `EnvKey` class makes any such mistake a visible `AttributeError`.

Fixes #14

## Test plan

- [ ] Grep confirms zero remaining bare `os.environ["BASE_MODEL_URL"]` / `os.environ["RESULT_SAVED_URL"]` / `os.environ["MODEL_URL"]` / `os.environ["MODEL_URLS"]` strings in paradigm code
- [ ] Existing unit tests pass unchanged (no behaviour change — purely a rename of the string literal)

Signed-off-by: dev-aditya-hub <premjadhvar95@gmail.com>