### PR TITLE
ci: add codespell spell-check workflow

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+[codespell]
+# examples/ and docs/proposals/ contain pre-existing issues from many
+# contributors; they are tracked separately. CI focuses on core/ only.
+skip = *.pyc,__pycache__,*.egg-info,.git

--- a/.github/workflows/spell-check.yml
+++ b/.github/workflows/spell-check.yml
@@ -1,0 +1,22 @@
+name: Spell Check
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  codespell:
+    runs-on: ubuntu-22.04
+    name: codespell
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.9"
+      - name: Install codespell
+        run: python -m pip install codespell
+      - name: Run codespell
+        run: codespell --config .codespellrc core

--- a/core/common/log.py
+++ b/core/common/log.py
@@ -21,7 +21,7 @@ import colorlog
 # pylint: disable=too-few-public-methods
 class Logger:
     """
-    Deafult logger in ianvs
+    Default logger in ianvs
     Args:
         name(str) : Logger name, default is 'ianvs'
     """

--- a/core/testcasecontroller/algorithm/paradigm/federated_learning/federated_class_incremental_learning.py
+++ b/core/testcasecontroller/algorithm/paradigm/federated_learning/federated_class_incremental_learning.py
@@ -249,7 +249,7 @@ class FederatedClassIncrementalLearning(FederatedLearning):
         if isinstance(testdataset_files, str):
             testdataset_files = [testdataset_files]
         job = self.get_global_model()
-        # caculate the seen class accuracy
+        # calculate the seen class accuracy
         old_class_acc_list = (
             []
         )  # for current round [class_0: acc_0, class_1: acc1, ....]
@@ -272,7 +272,7 @@ class FederatedClassIncrementalLearning(FederatedLearning):
         self.system_metric_info[SystemMetricType.TASK_AVG_ACC.value]["accuracy"] = (
             np.mean(old_class_acc_list)
         )
-        # caculate the forget rate
+        # calculate the forget rate
         for i in range(len(old_class_acc_list)):
             max_acc_diff = 0
             for j in range(incremental_round):

--- a/core/testcasecontroller/simulation/simulation.py
+++ b/core/testcasecontroller/simulation/simulation.py
@@ -18,7 +18,7 @@
 # pylint: disable=too-few-public-methods
 class Simulation:
     """
-    Simulation: The simulation enviroment, e.g. config of simulation.
+    Simulation: The simulation environment, e.g. config of simulation.
 
     Parameters
     ----------

--- a/core/testcasecontroller/simulation_system_admin/simulation_system_admin.py
+++ b/core/testcasecontroller/simulation_system_admin/simulation_system_admin.py
@@ -135,9 +135,9 @@ def check_host_cpu():
         raise RuntimeError("The number os cpus is insufficient.")
 
 
-def check_host_enviroment():
+def check_host_environment():
     """
-    check the host enviroment, includes docker, kind, cpu and memory.
+    check the host environment, includes docker, kind, cpu and memory.
 
     """
     check_host_docker()
@@ -146,13 +146,13 @@ def check_host_enviroment():
     check_host_cpu()
 
 
-def build_simulation_enviroment(simulation):
+def build_simulation_environment(simulation):
     """
-    build a simulation enviroment
+    build a simulation environment
 
     """
 
-    check_host_enviroment()         # check the enviroment
+    check_host_environment()         # check the environment
 
     shell_cmd = "curl https://raw.githubusercontent.com/kubeedge/sedna\
 /master/scripts/installation/all-in-one.sh | " \
@@ -167,14 +167,14 @@ def build_simulation_enviroment(simulation):
 
     if build_simulation_env_ret.returncode == 0:
         LOGGER.info(
-            "Congratulation! The simulation enviroment build successful!")
+            "Congratulation! The simulation environment build successful!")
     else:
-        raise RuntimeError("The simulation enviroment build failed.")
+        raise RuntimeError("The simulation environment build failed.")
 
 
-def destory_simulation_enviroment(simulation):
+def destory_simulation_environment(simulation):
     """
-    build the simulation enviroment
+    build the simulation environment
 
     """
     shell_cmd = "curl https://raw.githubusercontent.com/kubeedge/sedna\

--- a/core/testcasecontroller/simulation_system_admin/simulation_system_admin.py
+++ b/core/testcasecontroller/simulation_system_admin/simulation_system_admin.py
@@ -132,7 +132,7 @@ def check_host_cpu():
         LOGGER.info(
             "The number of cpus is insufficient. Number of Cpus: %s kB, Cpus Require: %s kB",
             number_of_cpus, cpus_require)
-        raise RuntimeError("The number os cpus is insufficient.")
+        raise RuntimeError("The number of cpus is insufficient.")
 
 
 def check_host_environment():
@@ -172,9 +172,9 @@ def build_simulation_environment(simulation):
         raise RuntimeError("The simulation environment build failed.")
 
 
-def destory_simulation_environment(simulation):
+def destroy_simulation_environment(simulation):
     """
-    build the simulation environment
+    destroy the simulation environment
 
     """
     shell_cmd = "curl https://raw.githubusercontent.com/kubeedge/sedna\

--- a/core/testenvmanager/dataset/dataset.py
+++ b/core/testenvmanager/dataset/dataset.py
@@ -228,7 +228,7 @@ class Dataset:
                 output_dir=output_dir,
                 times=times,
             )
-        # add new splitting method for semantic segmantation
+        # add new splitting method for semantic segmentation
         if method == "city_splitting":
             return self._city_splitting(
                 dataset_url,


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/spell-check.yml` that runs `codespell` on every `push` to `main` and every `pull_request`, preventing new spelling errors from landing in `core/`
- Adds `.codespellrc` to configure the check: scope is `core/` only; `examples/` and `docs/proposals/` contain pre-existing issues from many contributors and are tracked separately
- Fixes all typos that the new check surfaces in `core/`:
  - `Deafult` → `Default` (`core/common/log.py`)
  - `caculate` → `calculate` (`federated_class_incremental_learning.py`)
  - `enviroment` → `environment` (`simulation.py`, `simulation_system_admin.py`)
  - `segmantation` → `segmentation` (`dataset.py`)

## Why codespell

codespell is lightweight (pure Python, zero system deps), widely used in CNCF projects, and integrates in one `pip install` step — no extra Actions or third-party integrations required.

## Test plan

- [ ] CI workflow runs on this PR and exits 0
- [ ] `codespell --config .codespellrc core` exits 0 locally after applying the typo fixes

Fixes #232

Signed-off-by: dev-aditya-hub <premjadhvar95@gmail.com>