### PR TITLE
fix(government): restore singletask_learning_bench example

### DIFF
--- a/examples/government/singletask_learning_bench/README.md
+++ b/examples/government/singletask_learning_bench/README.md
@@ -1,104 +1,140 @@
-# Government BenchMark
+# Government Benchmark
 
-## Introduction
+This example runs the Ianvs single-task learning benchmark for the GovAff
+government affairs dataset. It contains two benchmark jobs:
 
-This is the work for Domain-specific Large Model Benchmark:
+- `objective`: multiple-choice government affairs questions, scored with `acc`
+- `subjective`: open-ended government affairs questions, scored by an LLM judge
 
-Constructs a suite for the government sector, including test datasets, evaluation metrics, testing environments, and usage guidelines.
+The commands below assume you run them from the repository root.
 
-This Benchmark consists of two parts: subjective evaluation data and objective evaluation data.
+## Requirements
 
-## Design
+- Python 3.9 or 3.10
+- Enough disk space for the GovAff dataset and the selected Hugging Face model
+- A Kaggle account/API token, or a browser download of the public dataset
+- A DeepSeek-compatible API key only if you run the subjective benchmark
 
-### Metadata Format
+## Install
 
-| Name | Field Name | Option | Description |
-| --- | --- | --- | --- |
-| Data Name | dataset |  Required | Name of the dataset |
-| Data Description | description | Optional | Dataset description, such as usage scope, sample size, etc. |
-| First-level Dimension | level_1_dim | Required | Should fill in "Single Modal" or "Multi-Modal" |
-| Second-level Dimension | level_2_dim | Required | For "Single Modal", fill in "Text", "Image", or "Audio". For "Multi-Modal", fill in "Text-Image", "Text-Audio", "Image-Audio", or "Text-Image-Audio" |
-| Third-level Dimension | level_3_dim | Optional | Should be filled if all samples in the dataset have the same third-level dimension. If filled, content should be based on the standards shown in the normative reference document |
-| Fourth-level Dimension | level_4_dim | Optional | Should be filled if all samples in the dataset have the same third-level dimension. If filled, content should be based on the standards shown in the normative reference document |
+```powershell
+python -m venv .venv
+.\.venv\Scripts\Activate.ps1
+python -m pip install --upgrade pip
+python -m pip install -e .
+python -m pip install -r examples/government/singletask_learning_bench/requirements.txt
+```
 
-metadata example:
+On Linux or macOS, activate the environment with:
+
+```bash
+source .venv/bin/activate
+```
+
+## Prepare Dataset
+
+Download the GovAff dataset from Kaggle:
+
+```powershell
+python -m pip install kaggle
+kaggle datasets download -d kubeedgeianvs/the-government-affairs-dataset-govaff -p dataset
+python -m zipfile -e dataset/the-government-affairs-dataset-govaff.zip dataset/govaff_raw
+python examples/government/singletask_learning_bench/prepare_dataset.py
+```
+
+If you download the zip in a browser, place it under `dataset/`, unzip it to
+`dataset/govaff_raw`, then run the same `prepare_dataset.py` command.
+
+After preparation, Ianvs should see this layout:
+
+```text
+dataset/government
+|-- objective
+|   |-- test_data
+|   |   |-- data.jsonl
+|   |   `-- metadata.json
+|   `-- train_data
+|       `-- data.jsonl
+`-- subjective
+    |-- test_data
+    |   |-- data.jsonl
+    |   `-- metadata.json
+    `-- train_data
+        `-- data.jsonl
+```
+
+The preparation step converts the current Kaggle folder names
+`government/multi-choice questions` and `government/subjective questions` into
+the paths expected by the Ianvs YAML files.
+
+## Model Configuration
+
+By default, both jobs load `Qwen/Qwen2-0.5B-Instruct` from Hugging Face. To use a
+local checkpoint or another compatible causal language model, set:
+
+```powershell
+$env:GOVERNMENT_BENCH_MODEL = "C:\path\to\model-or-huggingface-id"
+```
+
+On Linux or macOS:
+
+```bash
+export GOVERNMENT_BENCH_MODEL=/path/to/model-or-huggingface-id
+```
+
+The model uses CUDA when available and falls back to CPU.
+
+## Run
+
+Objective benchmark:
+
+```powershell
+ianvs -f examples/government/singletask_learning_bench/objective/benchmarkingjob.yaml
+```
+
+Subjective benchmark:
+
+```powershell
+$env:DEEPSEEK_API_KEY = "your_api_key"
+ianvs -f examples/government/singletask_learning_bench/subjective/benchmarkingjob.yaml
+```
+
+Optional subjective judge settings:
+
+```powershell
+$env:DEEPSEEK_BASE_URL = "https://api.deepseek.com"
+$env:DEEPSEEK_MODEL = "deepseek-chat"
+```
+
+Outputs are written under `workspace/government/objective` and
+`workspace/government/subjective`.
+
+## Data Format
+
+Metadata files use:
 
 ```json
 {
-    "dataset": "Medical BenchMark",
-    "description": "xxx",
+    "dataset": "A Objective BenchMark Template",
+    "description": "A government benchmark for llm testing",
     "level_1_dim": "single-modal",
     "level_2_dim": "text",
     "level_3_dim": "Q&A",
-    "level_4_dim": "medical"
+    "level_4_dim": "government"
 }
 ```
 
-### Data format:
-
-|name|Option|information|
-|---|---|---|
-|prompt|Optional|the background of the LLM testing|
-|query|Required|the testing question|
-|response|Required|the answer of the question|
-|explanation|Optional|the explanation of the answer|
-|judge_prompt|Optional|the prompt of the judge model|
-|level_1_dim|Optional|single-modal or multi-modal|
-|level_2_dim|Optional|single-modal: text, image, video; multi-modal: text-image, text-video, text-image-video|
-|level_3_dim|Required|details|
-|level_4_dim|Required|details|
-
-data example:
+Subjective test rows use the Sedna LLM metadata parser format:
 
 ```json
 {
-    "prompt": "Please think step by step and answer the question.",
-    "question": "Which one is the correct answer of xxx? A. xxx B. xxx C. xxx D. xxx",
-    "response": "C",
-    "explanation": "xxx",
+    "prompt": "System or task background.",
+    "query": "Question text.",
+    "response": "Reference answer.",
+    "judge_prompt": "Judge prompt ending before the candidate answer.",
     "level_1_dim": "single-modal",
     "level_2_dim": "text",
-    "level_3_dim": "knowledge Q&A",
-    "level_4_dim": "medical knowledge"
+    "level_3_dim": "Q&A",
+    "level_4_dim": "government"
 }
 ```
-
-
-## Change to Core Code
-
-![](./imgs/structure.png)
-
-## Prepare Datasets
-
-You can download dataset in [kaggle](https://www.kaggle.com/datasets/kubeedgeianvs/the-government-affairs-dataset-govaff/data?select=government_benchmark)
-
-```
-dataset/government
-├── objective
-│   ├── test_data
-│   │   ├── data.jsonl
-│   │   └── metadata.json
-│   └── train_data
-└── subjective
-    ├── test_data
-    │   ├── data_full.jsonl
-    │   ├── data.jsonl
-    │   └── metadata.json
-    └── train_data
-```
-
-## Prepare Environment
-
-You should change your sedna package like this: [my sedna repo commit](https://github.com/IcyFeather233/sedna/commit/e13b82363c03dc771fca4922a24798554ca32a9f)
-
-Or you can replace the file in `yourpath/anaconda3/envs/ianvs/lib/python3.x/site-packages/sedna` with `examples/resources/sedna-llm.zip`
-
-## Run Ianvs
-
-### Objective
-
-`ianvs -f examples/government/singletask_learning_bench/objective/benchmarkingjob.yaml`
-
-### Subjective
-
-`ianvs -f examples/government/singletask_learning_bench/subjective/benchmarkingjob.yaml`

--- a/examples/government/singletask_learning_bench/objective/benchmarkingjob.yaml
+++ b/examples/government/singletask_learning_bench/objective/benchmarkingjob.yaml
@@ -1,72 +1,22 @@
 benchmarkingjob:
-  # job name of bechmarking; string type;
   name: "benchmarkingjob"
-  # the url address of job workspace that will reserve the output of tests; string type;
-  workspace: "/home/icyfeather/project/ianvs/workspace"
-
-  # the url address of test environment configuration file; string type;
-  # the file format supports yaml/yml;
+  workspace: "./workspace/government/objective"
   testenv: "./examples/government/singletask_learning_bench/objective/testenv/testenv.yaml"
 
-  # the configuration of test object
   test_object:
-    # test type; string type;
-    # currently the option of value is "algorithms",the others will be added in succession.
     type: "algorithms"
-    # test algorithm configuration files; list type;
     algorithms:
-      # algorithm name; string type;
       - name: "politic_bench_singletask_learning"
-        # the url address of test algorithm configuration file; string type;
-        # the file format supports yaml/yml;
         url: "./examples/government/singletask_learning_bench/objective/testalgorithms/gen/gen_algorithm.yaml"
 
-  # the configuration of ranking leaderboard
   rank:
-    # rank leaderboard with metric of test case's evaluation and order ; list type;
-    # the sorting priority is based on the sequence of metrics in the list from front to back;
     sort_by: [ { "acc": "descend" } ]
-
-    # visualization configuration
     visualization:
-      # mode of visualization in the leaderboard; string type;
-      # There are quite a few possible dataitems in the leaderboard. Not all of them can be shown simultaneously on the screen.
-      # In the leaderboard, we provide the "selected_only" mode for the user to configure what is shown or is not shown.
       mode: "selected_only"
-      # method of visualization for selected dataitems; string type;
-      # currently the options of value are as follows:
-      #  1> "print_table": print selected dataitems;
       method: "print_table"
-
-    # selected dataitem configuration
-    # The user can add his/her interested dataitems in terms of "paradigms", "modules", "hyperparameters" and "metrics",
-    # so that the selected columns will be shown.
     selected_dataitem:
-      # currently the options of value are as follows:
-      #   1> "all": select all paradigms in the leaderboard;
-      #   2> paradigms in the leaderboard, e.g., "singletasklearning"
       paradigms: [ "all" ]
-      # currently the options of value are as follows:
-      #   1> "all": select all modules in the leaderboard;
-      #   2> modules in the leaderboard, e.g., "basemodel"
       modules: [ "all" ]
-      # currently the options of value are as follows:
-      #   1> "all": select all hyperparameters in the leaderboard;
-      #   2> hyperparameters in the leaderboard, e.g., "momentum"
       hyperparameters: [ "all" ]
-      # currently the options of value are as follows:
-      #   1> "all": select all metrics in the leaderboard;
-      #   2> metrics in the leaderboard, e.g., "f1_score"
       metrics: [ "acc" ]
-
-    # model of save selected and all dataitems in workspace; string type;
-    # currently the options of value are as follows:
-    #  1> "selected_and_all": save selected and all dataitems;
-    #  2> "selected_only": save selected dataitems;
     save_mode: "selected_and_all"
-
-
-
-
-
-

--- a/examples/government/singletask_learning_bench/objective/testalgorithms/gen/basemodel.py
+++ b/examples/government/singletask_learning_bench/objective/testalgorithms/gen/basemodel.py
@@ -14,22 +14,16 @@
 
 from __future__ import absolute_import, division
 
-import os
-import tempfile
-import time
-import zipfile
 import logging
-
-import numpy as np
+import os
 import random
+
+import torch
 from tqdm import tqdm
-from sedna.common.config import Context
 from sedna.common.class_factory import ClassType, ClassFactory
 from core.common.log import LOGGER
 
-
 from transformers import AutoModelForCausalLM, AutoTokenizer
-device = "cuda" # the device to load the model onto
 
 
 logging.disable(logging.WARNING)
@@ -43,12 +37,21 @@ os.environ['BACKEND_TYPE'] = 'TORCH'
 class BaseModel:
 
     def __init__(self, **kwargs):
-        self.model = AutoModelForCausalLM.from_pretrained(
-            "/home/icyfeather/models/Qwen2-0.5B-Instruct",
-            torch_dtype="auto",
-            device_map="auto"
+        self.model_name_or_path = os.getenv(
+            "GOVERNMENT_BENCH_MODEL",
+            "Qwen/Qwen2-0.5B-Instruct",
         )
-        self.tokenizer = AutoTokenizer.from_pretrained("/home/icyfeather/models/Qwen2-0.5B-Instruct")
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        model_kwargs = {"torch_dtype": "auto"}
+        if torch.cuda.is_available():
+            model_kwargs["device_map"] = "auto"
+        self.model = AutoModelForCausalLM.from_pretrained(
+            self.model_name_or_path,
+            **model_kwargs,
+        )
+        if not torch.cuda.is_available():
+            self.model.to(self.device)
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_name_or_path)
 
     def train(self, train_data, valid_data=None, **kwargs):
         LOGGER.info("BaseModel train")
@@ -59,19 +62,25 @@ class BaseModel:
 
     def predict(self, data, input_shape=None, **kwargs):
         LOGGER.info("BaseModel predict")
-        LOGGER.info(f"Dataset: {data.dataset_name}")
-        LOGGER.info(f"Description: {data.description}")
-        LOGGER.info(f"Data Level 1 Dim: {data.level_1_dim}")
-        LOGGER.info(f"Data Level 2 Dim: {data.level_2_dim}")
+        if hasattr(data, "dataset_name"):
+            LOGGER.info(f"Dataset: {data.dataset_name}")
+            LOGGER.info(f"Description: {data.description}")
+            LOGGER.info(f"Data Level 1 Dim: {data.level_1_dim}")
+            LOGGER.info(f"Data Level 2 Dim: {data.level_2_dim}")
         
+        questions = list(getattr(data, "x", data))
+        labels = list(getattr(data, "y", []))
         answer_list = []
-        for line in tqdm(data.x, desc="Processing", unit="question"):
-            # 3-shot
-            indices = random.sample([i for i, l in enumerate(data.x) if l != line], 3)
+        for line in tqdm(questions, desc="Processing", unit="question"):
+            candidates = [
+                i for i, question in enumerate(questions)
+                if question != line and i < len(labels)
+            ]
+            indices = random.sample(candidates, min(3, len(candidates)))
             history = []
             for idx in indices:
-                history.append({"role": "user", "content": data.x[idx]})
-                history.append({"role": "assistant", "content": data.y[idx]})
+                history.append({"role": "user", "content": questions[idx]})
+                history.append({"role": "assistant", "content": labels[idx]})
             history.append({"role": "user", "content": line})
             response = self._infer(history)
             answer_list.append(response)
@@ -89,7 +98,7 @@ class BaseModel:
             tokenize=False,
             add_generation_prompt=True
         )
-        model_inputs = self.tokenizer([text], return_tensors="pt").to(device)
+        model_inputs = self.tokenizer([text], return_tensors="pt").to(self.device)
         
         generated_ids = self.model.generate(
             model_inputs.input_ids,

--- a/examples/government/singletask_learning_bench/objective/testenv/testenv.yaml
+++ b/examples/government/singletask_learning_bench/objective/testenv/testenv.yaml
@@ -1,14 +1,8 @@
 testenv:
-  # dataset configuration
   dataset:
-    # the url address of train dataset index; string type;
-    train_data: "/home/icyfeather/Projects/ianvs/dataset/government/objective/train_data/data.jsonl"
-    # the url address of test dataset index; string type;
-    test_data_info: "/home/icyfeather/Projects/ianvs/dataset/government/objective/test_data/metadata.json"
+    train_data: "./dataset/government/objective/train_data/data.jsonl"
+    test_data_info: "./dataset/government/objective/test_data/metadata.json"
 
-  # metrics configuration for test case's evaluation; list type;
   metrics:
-      # metric name; string type;
     - name: "acc"
-      # the url address of python file
       url: "./examples/government/singletask_learning_bench/objective/testenv/acc.py"

--- a/examples/government/singletask_learning_bench/prepare_dataset.py
+++ b/examples/government/singletask_learning_bench/prepare_dataset.py
@@ -1,0 +1,137 @@
+#!/usr/bin/env python3
+# Copyright 2022 The KubeEdge Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+
+"""Prepare the GovAff Kaggle dataset for this Ianvs example."""
+
+import argparse
+import json
+import shutil
+from pathlib import Path
+
+
+OBJECTIVE_METADATA = {
+    "dataset": "A Objective BenchMark Template",
+    "description": "A government benchmark for llm testing",
+    "level_1_dim": "single-modal",
+    "level_2_dim": "text",
+    "level_3_dim": "Q&A",
+    "level_4_dim": "government",
+}
+
+SUBJECTIVE_METADATA = {
+    "dataset": "A Subjective BenchMark Template",
+    "description": "A government benchmark for llm testing",
+    "level_1_dim": "single-modal",
+    "level_2_dim": "text",
+    "level_3_dim": "Q&A",
+    "level_4_dim": "government",
+}
+
+
+def _read_jsonl(path):
+    with path.open("r", encoding="utf-8") as file:
+        for line in file:
+            if line.strip():
+                yield json.loads(line)
+
+
+def _write_json(path, payload):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as file:
+        json.dump(payload, file, ensure_ascii=False, indent=4)
+        file.write("\n")
+
+
+def _write_jsonl(path, rows):
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as file:
+        for row in rows:
+            file.write(json.dumps(row, ensure_ascii=False) + "\n")
+
+
+def _format_options(options):
+    labels = "ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+    return "\n".join(f"{labels[index]}. {option}" for index, option in enumerate(options))
+
+
+def _prepare_objective(source_dir, output_dir):
+    source_data = source_dir / "multi-choice questions" / "data.jsonl"
+    if not source_data.is_file():
+        raise FileNotFoundError(f"missing objective source data: {source_data}")
+
+    train_rows = []
+    test_rows = []
+    for row in _read_jsonl(source_data):
+        question = row["question"]
+        answer = row["answer"]
+        train_rows.append({"question": question, "answer": answer})
+        test_rows.append({
+            "query": f"{question}\n{_format_options(row['options'])}",
+            "response": answer,
+            "level_1_dim": OBJECTIVE_METADATA["level_1_dim"],
+            "level_2_dim": OBJECTIVE_METADATA["level_2_dim"],
+            "level_3_dim": OBJECTIVE_METADATA["level_3_dim"],
+            "level_4_dim": OBJECTIVE_METADATA["level_4_dim"],
+        })
+
+    target = output_dir / "objective"
+    _write_jsonl(target / "train_data" / "data.jsonl", train_rows)
+    _write_jsonl(target / "test_data" / "data.jsonl", test_rows)
+    _write_json(target / "test_data" / "metadata.json", OBJECTIVE_METADATA)
+
+
+def _prepare_subjective(source_dir, output_dir):
+    source_base = source_dir / "subjective questions"
+    source_data = source_base / "data.jsonl"
+    source_metadata = source_base / "metadata.json"
+    if not source_data.is_file():
+        raise FileNotFoundError(f"missing subjective source data: {source_data}")
+    if not source_metadata.is_file():
+        raise FileNotFoundError(f"missing subjective metadata: {source_metadata}")
+
+    train_rows = [
+        {"question": row["query"], "answer": row["response"]}
+        for row in _read_jsonl(source_data)
+    ]
+
+    target = output_dir / "subjective"
+    _write_jsonl(target / "train_data" / "data.jsonl", train_rows)
+    (target / "test_data").mkdir(parents=True, exist_ok=True)
+    shutil.copyfile(source_data, target / "test_data" / "data.jsonl")
+    shutil.copyfile(source_metadata, target / "test_data" / "metadata.json")
+
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--source",
+        type=Path,
+        default=Path("dataset/govaff_raw/government"),
+        help="Directory containing the unzipped Kaggle 'government' folder.",
+    )
+    parser.add_argument(
+        "--output",
+        type=Path,
+        default=Path("dataset/government"),
+        help="Directory where Ianvs-ready objective/subjective data is written.",
+    )
+    args = parser.parse_args()
+
+    source_dir = args.source.resolve()
+    output_dir = args.output.resolve()
+    if not source_dir.is_dir():
+        raise FileNotFoundError(f"source directory does not exist: {source_dir}")
+
+    _prepare_objective(source_dir, output_dir)
+    _prepare_subjective(source_dir, output_dir)
+    print(f"Prepared government benchmark dataset under {output_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/government/singletask_learning_bench/requirements.txt
+++ b/examples/government/singletask_learning_bench/requirements.txt
@@ -1,0 +1,18 @@
+# Install Ianvs itself from the repository root with:
+#   python -m pip install -e .
+#
+# Install the bundled Sedna wheel with:
+#   pip install examples/resources/third_party/sedna-0.6.0.1-py3-none-any.whl
+
+accelerate==0.30.1
+fastapi==0.95.2
+numpy==1.24.4
+openai==1.30.5
+pandas==1.5.3
+prettytable==2.5.0
+pydantic==1.10.15
+PyYAML==6.0.2
+torch==2.2.2
+tqdm==4.66.5
+transformers==4.40.2
+uvicorn==0.22.0

--- a/examples/government/singletask_learning_bench/subjective/benchmarkingjob.yaml
+++ b/examples/government/singletask_learning_bench/subjective/benchmarkingjob.yaml
@@ -1,72 +1,22 @@
 benchmarkingjob:
-  # job name of bechmarking; string type;
   name: "benchmarkingjob"
-  # the url address of job workspace that will reserve the output of tests; string type;
-  workspace: "/home/icyfeather/project/ianvs/workspace"
-
-  # the url address of test environment configuration file; string type;
-  # the file format supports yaml/yml;
+  workspace: "./workspace/government/subjective"
   testenv: "./examples/government/singletask_learning_bench/subjective/testenv/testenv.yaml"
 
-  # the configuration of test object
   test_object:
-    # test type; string type;
-    # currently the option of value is "algorithms",the others will be added in succession.
     type: "algorithms"
-    # test algorithm configuration files; list type;
     algorithms:
-      # algorithm name; string type;
       - name: "politic_bench_singletask_learning"
-        # the url address of test algorithm configuration file; string type;
-        # the file format supports yaml/yml;
         url: "./examples/government/singletask_learning_bench/subjective/testalgorithms/gen/gen_algorithm.yaml"
 
-  # the configuration of ranking leaderboard
   rank:
-    # rank leaderboard with metric of test case's evaluation and order ; list type;
-    # the sorting priority is based on the sequence of metrics in the list from front to back;
     sort_by: [ { "llm_judgement": "descend" } ]
-
-    # visualization configuration
     visualization:
-      # mode of visualization in the leaderboard; string type;
-      # There are quite a few possible dataitems in the leaderboard. Not all of them can be shown simultaneously on the screen.
-      # In the leaderboard, we provide the "selected_only" mode for the user to configure what is shown or is not shown.
       mode: "selected_only"
-      # method of visualization for selected dataitems; string type;
-      # currently the options of value are as follows:
-      #  1> "print_table": print selected dataitems;
       method: "print_table"
-
-    # selected dataitem configuration
-    # The user can add his/her interested dataitems in terms of "paradigms", "modules", "hyperparameters" and "metrics",
-    # so that the selected columns will be shown.
     selected_dataitem:
-      # currently the options of value are as follows:
-      #   1> "all": select all paradigms in the leaderboard;
-      #   2> paradigms in the leaderboard, e.g., "singletasklearning"
       paradigms: [ "all" ]
-      # currently the options of value are as follows:
-      #   1> "all": select all modules in the leaderboard;
-      #   2> modules in the leaderboard, e.g., "basemodel"
       modules: [ "all" ]
-      # currently the options of value are as follows:
-      #   1> "all": select all hyperparameters in the leaderboard;
-      #   2> hyperparameters in the leaderboard, e.g., "momentum"
       hyperparameters: [ "all" ]
-      # currently the options of value are as follows:
-      #   1> "all": select all metrics in the leaderboard;
-      #   2> metrics in the leaderboard, e.g., "f1_score"
       metrics: [ "llm_judgement" ]
-
-    # model of save selected and all dataitems in workspace; string type;
-    # currently the options of value are as follows:
-    #  1> "selected_and_all": save selected and all dataitems;
-    #  2> "selected_only": save selected dataitems;
     save_mode: "selected_and_all"
-
-
-
-
-
-

--- a/examples/government/singletask_learning_bench/subjective/testalgorithms/gen/basemodel.py
+++ b/examples/government/singletask_learning_bench/subjective/testalgorithms/gen/basemodel.py
@@ -14,22 +14,16 @@
 
 from __future__ import absolute_import, division
 
-import os
-import tempfile
-import time
-import zipfile
 import logging
+import os
 
-import numpy as np
-import random
+import torch
 from tqdm import tqdm
-from sedna.common.config import Context
 from sedna.common.class_factory import ClassType, ClassFactory
 from core.common.log import LOGGER
 from openai import OpenAI
 
 from transformers import AutoModelForCausalLM, AutoTokenizer
-device = "cuda" # the device to load the model onto
 
 
 logging.disable(logging.WARNING)
@@ -43,12 +37,21 @@ os.environ['BACKEND_TYPE'] = 'TORCH'
 class BaseModel:
 
     def __init__(self, **kwargs):
-        self.model = AutoModelForCausalLM.from_pretrained(
-            "/home/icyfeather/models/Qwen2-0.5B-Instruct",
-            torch_dtype="auto",
-            device_map="auto"
+        self.model_name_or_path = os.getenv(
+            "GOVERNMENT_BENCH_MODEL",
+            "Qwen/Qwen2-0.5B-Instruct",
         )
-        self.tokenizer = AutoTokenizer.from_pretrained("/home/icyfeather/models/Qwen2-0.5B-Instruct")
+        self.device = "cuda" if torch.cuda.is_available() else "cpu"
+        model_kwargs = {"torch_dtype": "auto"}
+        if torch.cuda.is_available():
+            model_kwargs["device_map"] = "auto"
+        self.model = AutoModelForCausalLM.from_pretrained(
+            self.model_name_or_path,
+            **model_kwargs,
+        )
+        if not torch.cuda.is_available():
+            self.model.to(self.device)
+        self.tokenizer = AutoTokenizer.from_pretrained(self.model_name_or_path)
 
     def train(self, train_data, valid_data=None, **kwargs):
         LOGGER.info("BaseModel train")
@@ -65,17 +68,20 @@ class BaseModel:
         LOGGER.info(f"Data Level 2 Dim: {data.level_2_dim}")
         
         answer_list = []
-        for line in tqdm(data.x, desc="Processing", unit="question"):
+        questions = list(data.x)
+        for line in tqdm(questions, desc="Processing", unit="question"):
             history = []
             history.append({"role": "user", "content": line})
             response = self._infer(history)
             answer_list.append(response)
 
         judgement_list = []
+        judge_prompts = getattr(data, "judge_prompts", None)
+        if judge_prompts is None:
+            raise ValueError("subjective benchmark data must be loaded from metadata.json")
 
-        # evaluate by llm
         for index in tqdm(range(len(answer_list)), desc="Evaluating", ascii=False, ncols=75):
-            prompt = data.judge_prompts[index] + answer_list[index]
+            prompt = judge_prompts[index] + answer_list[index]
             judgement = self._openai_generate(prompt)
             judgement_list.append(judgement)
 
@@ -93,7 +99,7 @@ class BaseModel:
             tokenize=False,
             add_generation_prompt=True
         )
-        model_inputs = self.tokenizer([text], return_tensors="pt").to(device)
+        model_inputs = self.tokenizer([text], return_tensors="pt").to(self.device)
         
         generated_ids = self.model.generate(
             model_inputs.input_ids,
@@ -113,7 +119,10 @@ class BaseModel:
         key = os.getenv("DEEPSEEK_API_KEY")
         if not key:
             raise ValueError("You should set DEEPSEEK_API_KEY in your env.")
-        client = OpenAI(api_key=key, base_url="https://api.deepseek.com")
+        client = OpenAI(
+            api_key=key,
+            base_url=os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com"),
+        )
 
         messages = []
         if system:
@@ -121,7 +130,7 @@ class BaseModel:
         messages.append({"role": "user", "content": user_question})
 
         response = client.chat.completions.create(
-            model="deepseek-chat",
+            model=os.getenv("DEEPSEEK_MODEL", "deepseek-chat"),
             messages=messages,
             stream=False
         )

--- a/examples/government/singletask_learning_bench/subjective/testenv/llm_judgement.py
+++ b/examples/government/singletask_learning_bench/subjective/testenv/llm_judgement.py
@@ -13,28 +13,34 @@
 # limitations under the License.
 
 import re
-from sedna.common.class_factory import ClassType, ClassFactory
+
 from core.common.log import LOGGER
+from sedna.common.class_factory import ClassFactory, ClassType
 
 __all__ = ["llm_judgement"]
 
+
 def extract_comprehensive_score(input_str):
-    # extract overall points
-    match = re.search(r"'Overall Points': (\d+)", input_str)
-    if match:
-        return int(match.group(1))
-    else:
-        return None
+    patterns = [
+        r"['\"]Overall Points['\"]\s*:\s*(\d+)",
+        r"['\"]\u7efc\u5408\u5f97\u5206['\"]\s*[:\uff1a]\s*(\d+)",
+        r"\u7efc\u5408(?:\u5f97\u5206|\u5206\u6570)\D{0,8}(\d+)",
+    ]
+    for pattern in patterns:
+        match = re.search(pattern, input_str)
+        if match:
+            return int(match.group(1))
+    return None
 
 
 @ClassFactory.register(ClassType.GENERAL, alias="llm_judgement")
 def llm_judgement(y_true, y_pred):
     y_pred = [extract_comprehensive_score(pred) for pred in y_pred]
-        
+
     valid_scores = [score for score in y_pred if score is not None]
 
     LOGGER.info(f"Extracted {len(valid_scores)} datas from {len(y_pred)} datas")
-    
+
     if valid_scores:
         average_score = sum(valid_scores) / len(valid_scores)
         return average_score

--- a/examples/government/singletask_learning_bench/subjective/testenv/testenv.yaml
+++ b/examples/government/singletask_learning_bench/subjective/testenv/testenv.yaml
@@ -1,14 +1,8 @@
 testenv:
-  # dataset configuration
   dataset:
-    # the url address of train dataset index; string type;
-    train_data: "/home/icyfeather/Projects/ianvs/dataset/government/subjective/train_data/data.jsonl"
-    # the url address of test dataset index; string type;
-    test_data_info: "/home/icyfeather/Projects/ianvs/dataset/government/subjective/test_data/metadata.json"
+    train_data: "./dataset/government/subjective/train_data/data.jsonl"
+    test_data_info: "./dataset/government/subjective/test_data/metadata.json"
 
-  # metrics configuration for test case's evaluation; list type;
   metrics:
-      # metric name; string type;
     - name: "llm_judgement"
-      # the url address of python file
       url: "./examples/government/singletask_learning_bench/subjective/testenv/llm_judgement.py"


### PR DESCRIPTION
Restores the government single-task learning benchmark so contributors can run it on Python 3.9/3.10 without manual debugging.

## Changes

- Add pinned per-example requirements.txt
- Replace all hardcoded /home/icyfeather/... paths in YAML files with repo-relative paths
- Add prepare_dataset.py to convert current GovAff Kaggle layout into Ianvs-ready objective/subjective folders
- Make model path configurable via GOVERNMENT_BENCH_MODEL env var with Qwen/Qwen2-0.5B-Instruct as default
- Add CUDA/CPU fallback in both basemodel.py files
- Fix subjective score extraction regex to handle Chinese judge prompt format (综合得分)
- Update README with accurate install, dataset download, preparation, model config, and run instructions

## Verification

- python -m py_compile passed on all changed Python files
- llm_judgement score extraction tested for Overall Points, 综合得分, and 综合分数 patterns
- All YAML files parse with yaml.safe_load
- Dataset preparation tested against current GovAff Kaggle zip, produced 1600 objective rows and 1045 subjective rows
- No remaining /home, /root, hardcoded model paths, or TODO markers in target directory

Fixes #425

cc @MooreZheng