### PR TITLE
Fix/llm simple qa pipeline

### DIFF
--- a/core/testenvmanager/dataset/dataset.py
+++ b/core/testenvmanager/dataset/dataset.py
@@ -16,19 +16,37 @@
 
 import os
 import tempfile
+import json
 
 import pandas as pd
 from sedna.datasources import (
     CSVDataParse,
     TxtDataParse,
     JSONDataParse,
-    JsonlDataParse,
-    JSONMetaDataParse
 )
-
+from sedna.datasources import BaseDataSource
 from core.common import utils
 from core.common.constant import DatasetFormat
 
+class JsonlDataParse(BaseDataSource):
+    def __init__(self, data_type="train", func=None):
+        super().__init__(data_type=data_type, func=func)
+
+    def parse(self, filepath):
+        self.x = []
+        self.y = []
+        with open(filepath, "r", encoding="utf-8") as f:
+            for line in f:
+                if line.strip():
+                    raw_data = json.loads(line.strip())
+                    if isinstance(raw_data, dict):
+                        question = raw_data.get("question", raw_data.get("input", ""))
+                        answer = raw_data.get("answer", raw_data.get("output", ""))
+                        self.x.append(str(question))
+                        self.y.append(str(answer))
+                    else:
+                        self.x.append(str(raw_data))
+                        self.y.append("")
 # pylint: disable=too-many-instance-attributes
 class Dataset:
     """
@@ -588,7 +606,7 @@ class Dataset:
             data.parse(file)
 
         if data_format == DatasetFormat.JSONFORLLM.value:
-            data = JSONMetaDataParse(data_type=data_type, func=feature_process)
+            data = JSONDataParse(data_type=data_type, func=feature_process)
             data.parse(file, **kwargs)
 
         return data

--- a/examples/llm_simple_qa/benchmarkingjob.yaml
+++ b/examples/llm_simple_qa/benchmarkingjob.yaml
@@ -2,11 +2,11 @@ benchmarkingjob:
   # job name of bechmarking; string type;
   name: "benchmarkingjob"
   # the url address of job workspace that will reserve the output of tests; string type;
-  workspace: "/home/icyfeather/project/ianvs/workspace"
+  workspace: "./workspace"
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;
-  testenv: "./examples/llm/singletask_learning_bench/simple_qa/testenv/testenv.yaml"
+  testenv: "./examples/llm_simple_qa/testenv/testenv.yaml"
 
   # the configuration of test object
   test_object:
@@ -19,7 +19,7 @@ benchmarkingjob:
       - name: "simple_qa_singletask_learning"
         # the url address of test algorithm configuration file; string type;
         # the file format supports yaml/yml;
-        url: "./examples/llm/singletask_learning_bench/simple_qa/testalgorithms/gen/gen_algorithm.yaml"
+        url: "./examples/llm_simple_qa/testalgorithms/gen/gen_algorithm.yaml"
 
   # the configuration of ranking leaderboard
   rank:

--- a/examples/llm_simple_qa/testalgorithms/gen/basemodel.py
+++ b/examples/llm_simple_qa/testalgorithms/gen/basemodel.py
@@ -26,7 +26,8 @@ from sedna.common.class_factory import ClassType, ClassFactory
 
 
 from transformers import AutoModelForCausalLM, AutoTokenizer
-device = "cuda" # the device to load the model onto
+import torch
+device = "cuda" if torch.cuda.is_available() else "cpu" # the device to load the model onto
 
 
 logging.disable(logging.WARNING)
@@ -40,12 +41,16 @@ os.environ['BACKEND_TYPE'] = 'TORCH'
 class BaseModel:
 
     def __init__(self, **kwargs):
+        model_id = "Qwen/Qwen2-0.5B-Instruct"
         self.model = AutoModelForCausalLM.from_pretrained(
-            "/home/icyfeather/models/Qwen2-0.5B-Instruct",
+            model_id,
             torch_dtype="auto",
             device_map="auto"
         )
-        self.tokenizer = AutoTokenizer.from_pretrained("/home/icyfeather/models/Qwen2-0.5B-Instruct")
+        self.tokenizer = AutoTokenizer.from_pretrained(model_id)
+
+    def preprocess(self, *args, **kwargs):
+        return self
 
     def train(self, train_data, valid_data=None, **kwargs):
         print("BaseModel doesn't need to train")

--- a/examples/llm_simple_qa/testalgorithms/gen/gen_algorithm.yaml
+++ b/examples/llm_simple_qa/testalgorithms/gen/gen_algorithm.yaml
@@ -15,4 +15,4 @@ algorithm:
       # example: basemodel.py has BaseModel module that the alias is "FPN" for this benchmarking;
       name: "gen"
       # the url address of python module; string type;
-      url: "./examples/llm/singletask_learning_bench/simple_qa/testalgorithms/gen/basemodel.py"
+      url: "./examples/llm_simple_qa/testalgorithms/gen/basemodel.py"

--- a/examples/llm_simple_qa/testenv/testenv.yaml
+++ b/examples/llm_simple_qa/testenv/testenv.yaml
@@ -2,13 +2,13 @@ testenv:
   # dataset configuration
   dataset:
     # the url address of train dataset index; string type;
-    train_data: "/home/icyfeather/Projects/ianvs/dataset/llm_simple_qa/train_data/data.jsonl"
+    train_data: "./examples/llm_simple_qa/dataset/llm_simple_qa/train_data/data.jsonl"
     # the url address of test dataset index; string type;
-    test_data: "/home/icyfeather/Projects/ianvs/dataset/llm_simple_qa/test_data/data.jsonl"
+    test_data: "./examples/llm_simple_qa/dataset/llm_simple_qa/test_data/data.jsonl"
 
   # metrics configuration for test case's evaluation; list type;
   metrics:
       # metric name; string type;
     - name: "acc"
       # the url address of python file
-      url: "./examples/llm/singletask_learning_bench/simple_qa/testenv/acc.py"
+      url: "./examples/llm_simple_qa/testenv/acc.py"


### PR DESCRIPTION
## Description
This PR restores the functionality of the `llm_simple_qa` benchmarking pipeline. It addresses upstream API structural drift between KubeEdge/Ianvs and KubeEdge/Sedna, patches interface gaps in the local base model implementation, and refactors absolute directory paths into portable relative paths.

### Type of Change
- > Bug fix (non-breaking change which fixes an issue)
- > Code cleanup

## Problem Analysis & Solution Breakdown

### 1. Upstream Dependency & Formatting Realignment
->  **Problem**: The upstream Sedna library expects `JSONDataParse` to parse legacy computer vision (COCO) formats, triggering a `NameError: name 'COCO' is not defined` when processing text lines. Additionally, case-sensitivity changes in the library caused `JsonlDataParse` imports to break.
-> **Solution:** Designed and injected a dedicated, localized `JsonlDataParse` class within `core/testenvmanager/dataset/dataset.py` that reads text queries line-by-line natively via standard JSON, isolating the text evaluation pipeline from legacy computer vision footprints.

### 2. Paradigm Interface Completion
-> **Problem:** The `singletask_learning` paradigm executes a mandatory data prep loop that threw an `AttributeError: 'BaseModel' object has no attribute 'preprocess'`.
-> **Solution:** Added a compliant `preprocess` method to the `BaseModel` class within `examples/llm_simple_qa/testalgorithms/gen/basemodel.py` to satisfy the interface lifecycle verification.

### 3. Path Invariance & Configuration Portability
-> **Problem:** Configuration files contained hardcoded absolute file paths pointing to external development directories, rendering the example non-functional on new client setups or CI/CD runner nodes.
-> **Solution:** Normalized all target configurations (`benchmarkingjob.yaml`, `testenv.yaml`, `gen_algorithm.yaml`) to clean, location-invariant relative URLs targeting the root execution environment.

## How Has This Been Tested?
Tested locally inside a sandboxed WSL2 Ubuntu virtual environment in Windows on CPU execution mode:
1. Navigated to the repository root.
2. Verified localized file structures and initialized dependencies.
3. Executed the validation framework entry point in the terminal:
   python3 benchmarking.py -f examples/llm_simple_qa/benchmarkingjob.yaml