### PR TITLE
[LFX Term : 01 ]Restoration: CItyscape-Sythia Curb detection

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Local/generated artifacts
+sedna_src/
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]

--- a/core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py
+++ b/core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py
@@ -268,7 +268,7 @@ class LifelongLearning(ParadigmBase):
                     train_dataset_file, eval_dataset_file = dataset_files[r - 1]
                     self.cloud_task_index = self._train(self.cloud_task_index,
                                                         train_dataset_file,
-                                                        r)
+                                                        0)
                     self.edge_task_index = self._eval(self.cloud_task_index,
                                                       eval_dataset_file,
                                                       r)
@@ -344,8 +344,8 @@ class LifelongLearning(ParadigmBase):
         del job
 
         unseen_task_train_samples = BaseDataSource(data_type="train")
-        unseen_task_train_samples.x = np.array(unseen_tasks)
-        unseen_task_train_samples.y = np.array(unseen_task_labels)
+        unseen_task_train_samples.x = np.array(unseen_tasks, dtype=object)
+        unseen_task_train_samples.y = np.array(unseen_task_labels, dtype=object)
 
         return inference_results, unseen_task_train_samples
 
@@ -389,7 +389,8 @@ class LifelongLearning(ParadigmBase):
 
         job = self.build_paradigm_job(ParadigmType.LIFELONG_LEARNING.value)
         _, metric_func = get_metric_func(model_metric)
-        edge_task_index = job.evaluate(eval_dataset, metrics=metric_func)
+        job.evaluate(eval_dataset, metrics=metric_func)
+        edge_task_index = os.path.join(eval_output_dir, "index.pkl")
 
         del job
 

--- a/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/README.md
+++ b/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/README.md
@@ -1,104 +1,456 @@
-# Quick Start
+# Curb Detection with Lifelong Learning on Cityscapes-SYNTHIA
 
-Welcome to Ianvs! Ianvs aims to test the performance of distributed synergy AI solutions following recognized standards, 
-in order to facilitate more efficient and effective development. Quick start helps you to test your algorithm on Ianvs 
-with a simple example of industrial defect detection. You can reduce manual procedures to just a few steps so that you can 
-build and start your distributed synergy AI solution development within minutes. 
+This benchmark evaluates **lifelong learning** algorithms for autonomous driving curb detection. The model trains on a mix of real (Cityscapes) and simulated (SYNTHIA) data across multiple incremental rounds, measuring how well it transfers knowledge from simulation to real-world scenes.
 
-Before using Ianvs, you might want to have the device ready: 
-- One machine is all you need, i.e., a laptop or a virtual machine is sufficient and a cluster is not necessary
-- 2 CPUs or more
-- 4GB+ free memory, depends on algorithm and simulation setting
-- 10GB+ free disk space
-- Internet connection for GitHub and pip, etc
-- Python 3.6+ installed
-  
+---
 
-In this example, we are using the Linux platform with Python 3.8.5. If you are using Windows, most steps should still apply but a few like commands and package requirements might be different. 
+## Table of Contents
 
-## Step 1. Ianvs Preparation
+1. [Overview](#overview)
+2. [System Requirements](#system-requirements)
+3. [Step 1 — Ianvs Installation](#step-1--ianvs-installation)
+4. [Step 2 — Dataset Preparation](#step-2--dataset-preparation)
+5. [Step 3 — Configuration](#step-3--configuration)
+6. [Step 4 — Run the Benchmark](#step-4--run-the-benchmark)
+7. [Step 5 — Reading Results](#step-5--reading-results)
+8. [File Structure](#file-structure)
+9. [Troubleshooting](#troubleshooting)
 
-First, we download the code of Ianvs. Assuming that we are using `/ianvs` as workspace, Ianvs can be cloned with `Git`
-as:
+---
 
-``` shell
-mkdir /ianvs
-cd /ianvs #One might use another path preferred
+## Overview
 
-mkdir project
-cd project
-git clone https://github.com/kubeedge/ianvs.git   
+| Property | Value |
+|---|---|
+| Paradigm | Lifelong Learning |
+| Algorithm | RFNet (RGB + Depth Fusion Network) |
+| Dataset | Cityscapes (real) + SYNTHIA (simulated) |
+| Task | Semantic segmentation — curb class detection |
+| Metrics | `accuracy` (mIoU-based), `samples_transfer_ratio` |
+| Incremental Rounds | 2 |
+
+**Lifelong learning flow:**
+```
+Round 1: Train on seen tasks → Evaluate → Inference (detect unseen samples)
+Round 2: Re-train with transferred samples → Evaluate → Final inference
 ```
 
+The `samples_transfer_ratio` metric measures how many inference samples were identified as coming from an unseen task distribution and transferred for re-training. A non-zero ratio indicates the unseen task detection is working.
 
-Then, we install third-party dependencies for ianvs. 
-``` shell
+---
+
+## System Requirements
+
+| Requirement | Minimum | Recommended |
+|---|---|---|
+| OS | Linux (Ubuntu 20.04+) | Ubuntu 22.04 |
+| CPUs | 2 | 4+ |
+| RAM | 8 GB | 16 GB |
+| Disk | 10 GB free | 20 GB free |
+| Python | 3.8 | 3.8 |
+| GPU | Not required | CUDA-capable GPU |
+
+> **Note:** The benchmark runs on CPU. A GPU will significantly speed up training but is not mandatory.
+
+---
+
+## Step 1 — Ianvs Installation
+
+### 1.1 Clone the repository
+
+```bash
+git clone https://github.com/kubeedge/ianvs.git
+cd ianvs
+```
+
+### 1.2 Create and activate a virtual environment
+
+```bash
+python3 -m venv ianvs_env
+source ianvs_env/bin/activate
+```
+
+### 1.3 Install system dependencies
+
+```bash
 sudo apt-get update
-sudo apt-get install libgl1-mesa-glx -y
-python -m pip install --upgrade pip
-
-cd ianvs 
-python -m pip install ./examples/resources/third_party/*
-python -m pip install -r requirements.txt
+sudo apt-get install -y libgl1-mesa-glx libglib2.0-0
 ```
 
-We are now ready to install Ianvs. 
-``` shell
-python setup.py install  
+### 1.4 Install Python dependencies
+
+```bash
+pip install --upgrade pip
+pip install -r requirements.txt
 ```
 
-## Step 2. Dataset Preparation
+### 1.5 Install Ianvs
 
-Datasets and models can be large. To avoid over-size projects in the Github repository of Ianvs, the Ianvs code base does
-not include origin datasets. Then developers do not need to download non-necessary datasets for a quick start.
+```bash
+pip install -e .
+```
 
-``` shell
-cd /ianvs #One might use another path preferred
-mkdir dataset   
+Verify the installation:
+
+```bash
+ianvs --help
+```
+
+---
+
+## Step 2 — Dataset Preparation
+
+### 2.1 Download the dataset
+
+```bash
+mkdir -p dataset
 cd dataset
 wget https://kubeedge.obs.cn-north-1.myhuaweicloud.com/ianvs/curb-detection/curb-detection.zip
-unzip dataset.zip
+unzip curb-detection.zip
+cd ..
 ```
 
-The URL address of this dataset then should be filled in the configuration file ``testenv.yaml``. In this quick start,
-we have done that for you and the interested readers can refer to [testenv.yaml](https://ianvs.readthedocs.io/en/latest/guides/how-to-test-algorithms.html#step-1-test-environment-preparation) for more details.
+After extraction, the dataset directory should look like:
 
-<!-- Please put the downloaded dataset on the above dataset path, e.g., `/ianvs/dataset`. One can transfer the dataset to the path, e.g., on a remote Linux system using [XFTP].  -->
-
-
-Related algorithm is also ready in this quick start. 
-``` shell
-export PYTHONPATH=$PYTHONPATH:/ianvs/project/ianvs/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/RFNet
+```
+dataset/
+└── curb-detection/
+    ├── train_data/
+    │   ├── images/
+    │   │   ├── real_aachen_000000_000019_leftImg8bit.png
+    │   │   ├── real_aachen_000000_000019_gtFine_labelTrainIds.png
+    │   │   └── ...
+    │   └── index.txt          # 600 training samples
+    └── test_data/
+        ├── images/
+        │   └── ...
+        └── index.txt          # 201 test samples
 ```
 
-The URL address of this algorithm then should be filled in the configuration file ``algorithm.yaml``. In this quick
-start, we have done that for you and the interested readers can refer to [algorithm.yaml](https://ianvs.readthedocs.io/en/latest/guides/how-to-test-algorithms.html#step-1-test-environment-preparation) for more details.
+### 2.2 Index file format
 
-## Step 3. Ianvs Execution and Presentation
+Each line in an index file contains two space-separated paths — the RGB image and its corresponding label mask:
 
-We are now ready to run the ianvs for benchmarking. 
-
-``` shell
-cd /ianvs/project/ianvs
-ianvs -f examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/benchmarkingjob.yaml
+```
+./images/real_aachen_000000_000019_leftImg8bit.png ./images/real_aachen_000000_000019_gtFine_labelTrainIds.png
+./images/sim_00001_leftImg8bit.png ./images/sim_00001_gtFine_labelTrainIds.png
 ```
 
-Finally, the user can check the result of benchmarking on the console and also in the output path(
-e.g. `/ianvs/lifelong_learning_bench/workspace`) defined in the benchmarking config file (
-e.g. `benchmarkingjob.yaml`). In this quick start, we have done all configurations for you and the interested readers
-can refer to [benchmarkingJob.yaml](https://ianvs.readthedocs.io/en/latest/guides/how-to-test-algorithms.html#step-1-test-environment-preparation) for more details.
+- Files prefixed with `real_` are from **Cityscapes** (real camera footage).
+- Files prefixed with `sim_` are from **SYNTHIA** (synthetic/simulated).
 
-The final output might look like this:   
+The `task_definition_by_origin.py` module uses city names in the path (e.g. `aachen`, `berlin`) to automatically classify samples as real or simulated. You do not need to label them separately.
 
-|rank  |algorithm                |accuracy  |samples_transfer_ratio|paradigm            |basemodel  |task_definition       |task_allocation        |basemodel-learning_rate  |task_definition-origins|task_allocation-origins |                                                                                                    
-|:----:|:-----------------------:|:--------:|:--------------------:|:------------------:|:---------:|:--------------------:|:---------------------:|:-----------------------:|:----------------------|:-----------------------|
-|1     |rfnet_lifelong_learning  | 0.2123   |0.4649                |lifelonglearning    | BaseModel |TaskDefinitionByOrigin| TaskAllocationByOrigin|0.0001                   |['real', 'sim']        |['real', 'sim']         |
+### 2.3 Symlink an existing dataset (alternative)
 
+If the dataset already exists elsewhere on disk:
 
-This ends the quick start experiment.
+```bash
+ln -sfn /path/to/existing/curb-detection dataset/curb-detection
+```
 
-# What is next
+---
 
-If any problems happen, the user can refer to [the issue page on Github](https://github.com/kubeedge/ianvs/issues) for help and are also welcome to raise any new issue. 
+## Step 3 — Configuration
 
-Enjoy your journey on Ianvs!
+All configuration lives in three YAML files.
+
+### 3.1 `benchmarkingjob.yaml`
+
+Located at: `examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/benchmarkingjob.yaml`
+
+Key settings:
+
+| Field | Value | Description |
+|---|---|---|
+| `workspace` | `./workspace/curb-detection` | Where outputs are written |
+| `testenv` | path to `testenv.yaml` | Test environment config |
+| `algorithms[0].url` | path to `rfnet_algorithm.yaml` | Algorithm config |
+| `sort_by` | `accuracy descend` | Leaderboard sort order |
+| `metrics` | `accuracy`, `samples_transfer_ratio` | Metrics shown in results |
+
+### 3.2 `testenv/testenv.yaml`
+
+Located at: `examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testenv/testenv.yaml`
+
+```yaml
+testenv:
+  dataset:
+    train_index: "./dataset/curb-detection/train_data/index.txt"
+    test_index:  "./dataset/curb-detection/test_data/index.txt"
+
+  model_eval:
+    model_metric:
+      name: "accuracy"
+      url: "./examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testenv/accuracy.py"
+    threshold: 0
+    operator: "<"
+
+  metrics:
+    - name: "accuracy"
+      url: "./examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testenv/accuracy.py"
+    - name: "samples_transfer_ratio"
+
+  incremental_rounds: 2
+```
+
+### 3.3 `testalgorithms/rfnet/rfnet_algorithm.yaml`
+
+Key hyperparameters under `modules[basemodel].hyperparameters`:
+
+| Parameter | Default | Description |
+|---|---|---|
+| `learning_rate` | `0.0001` | Adam optimizer learning rate |
+| `epochs` | `1` | Training epochs per round |
+| `base_size` | `1024` | Image resize base dimension |
+| `crop_size` | `768` | Training crop dimension |
+| `batch_size` | `4` | Samples per training batch |
+| `workers` | `4` | DataLoader worker threads |
+
+---
+
+## Step 4 — Run the Benchmark
+
+Run from the **root of the ianvs repository**. The `PYTHONPATH` must include `sedna_src` and the `RFNet` directory.
+
+### Run command (copy as one line)
+
+```bash
+cd /path/to/ianvs && PYTHONPATH=/path/to/ianvs/sedna_src:/path/to/ianvs/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/RFNet ianvs -f examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/benchmarkingjob.yaml
+```
+
+Replace `/path/to/ianvs` with your actual repository path.
+
+> **Important:** Run the command as a single line. Do not press Enter in the middle of the `PYTHONPATH=...` value — splitting it will cause a "No such file or directory" error.
+
+> **Important:** Always run from the repository root, not from inside the example directory. All paths in YAML files are relative to the repo root.
+
+### What happens during a run
+
+```
+[Round 1]
+  Train  → RFNet trains on 80% of train_index samples
+  Eval   → mIoU accuracy computed on test_index
+  Infer  → Model predicts on 20% held-out samples; ~50% flagged as unseen
+
+[Round 2]
+  Train  → Re-trains with unseen samples transferred
+  Eval   → Final mIoU computed
+  Infer  → Final inference; samples_transfer_ratio calculated
+
+[Rank]   → Results printed to console and saved to workspace/
+```
+
+---
+
+## Step 5 — Reading Results
+
+Results are printed to the console and saved in:
+
+```
+workspace/curb-detection/benchmarkingjob/rank/
+├── selected_rank.csv    # columns: rank, algorithm, accuracy, samples_transfer_ratio, ...
+└── all_rank.csv         # all hyperparameter combinations
+```
+
+### Example output
+
+```
+| rank | algorithm               | accuracy | samples_transfer_ratio |
+|  1   | rfnet_lifelong_learning | 0.2123   | 0.4649                 |
+```
+
+### Metric definitions
+
+| Metric | Formula | Meaning |
+|---|---|---|
+| `accuracy` | mean of (CPA + mIoU + FWIoU) / 3 | Segmentation quality across all classes |
+| `samples_transfer_ratio` | `unseen_count / (total_infer + 1)` | Fraction of samples identified as unseen tasks; measures knowledge transfer activity |
+
+- Higher `accuracy` is better.
+- A non-zero `samples_transfer_ratio` confirms the unseen task detection pipeline is active.
+
+---
+
+## File Structure
+
+```
+examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/
+├── README.md                          ← this file
+├── benchmarkingjob.yaml               ← top-level benchmark config
+├── testenv/
+│   ├── testenv.yaml                   ← dataset paths, metrics, eval thresholds
+│   └── accuracy.py                    ← mIoU/CPA/FWIoU metric implementation
+└── testalgorithms/
+    └── rfnet/
+        ├── rfnet_algorithm.yaml       ← algorithm + hyperparameter config
+        ├── basemodel.py               ← BaseModel: train/predict/evaluate/load/save
+        ├── task_definition_by_origin.py  ← splits data into real/sim tasks
+        ├── task_allocation_by_origin.py  ← routes inference samples to correct task model
+        └── RFNet/                     ← RFNet model implementation
+            ├── train.py
+            ├── eval.py
+            ├── dataloaders/
+            │   └── datasets/
+            │       └── cityscapes.py  ← dataset loader (handles real + sim)
+            └── utils/
+                ├── args.py            ← TrainArgs / ValArgs with defaults
+                ├── metrics.py         ← confusion matrix + mIoU calculations
+                └── summaries.py       ← TensorBoard writer helpers
+```
+
+---
+
+## Troubleshooting
+
+### `bash: net/RFNet: No such file or directory`
+
+The command was copy-pasted across multiple lines and the path broke. Run the entire command on **one line**.
+
+---
+
+### `ModuleNotFoundError: No module named 'sedna'`
+
+Either sedna is not installed or `sedna_src` is missing from `PYTHONPATH`.
+
+**Fix A — install the wheel:**
+```bash
+pip install examples/resources/third_party/sedna-0.6.0.1-py3-none-any.whl
+```
+
+**Fix B — use sedna_src (local dev):**
+```bash
+export PYTHONPATH=/path/to/ianvs/sedna_src:$PYTHONPATH
+```
+
+---
+
+### `ModuleNotFoundError: No module named 'RFNet'` or `No module named 'mypath'`
+
+The `RFNet` directory is not in `PYTHONPATH`.
+
+**Fix:**
+```bash
+export PYTHONPATH=/path/to/ianvs/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/RFNet:$PYTHONPATH
+```
+
+---
+
+### `FileNotFoundError: dataset/curb-detection/...`
+
+The dataset directory does not exist at `./dataset/curb-detection/` relative to the repo root.
+
+**Fix A — download the dataset** (see Step 2).
+
+**Fix B — symlink an existing copy:**
+```bash
+ln -sfn /path/to/existing/curb-detection dataset/curb-detection
+```
+
+---
+
+### `PermissionError: /var/lib/sedna/kb`
+
+Sedna is trying to write its knowledge base to a system path that requires root.
+
+**Fix:** Ensure `sedna_src/sedna/common/constant.py` uses a user-writable path:
+```python
+import os
+EDGE_KB_DIR = os.path.expanduser("~/.sedna/kb")
+```
+
+---
+
+### `Connection refused: http://127.0.0.1:9100/sedna/workers/...`
+
+This warning appears because ianvs expects a KubeEdge edge node to be running locally. In a standalone local setup, no edge node is present.
+
+**This is expected and does not block execution.** The benchmark will complete normally despite these warnings.
+
+---
+
+### `ValueError: can't find class type knowledge_management class name UpdateStrategyDefault`
+
+The `UpdateStrategyDefault` class is not registered in sedna 0.6.0.1.
+
+**Fix:** In `sedna_src/sedna/algorithms/seen_task_learning/__init__.py`, add:
+```python
+from . import task_update_decision
+```
+
+And ensure `task_update_decision_finetune.py` contains the `UpdateStrategyDefault` class implementation. See the sedna patches applied in this branch for the full implementation.
+
+---
+
+### `AttributeError: 'TaskDefinitionByOrigin' object has no attribute 'get'`
+
+Sedna's `SeenTaskLearning._task_definition()` expects a dict but ianvs passes a class instance.
+
+**Fix:** In `sedna_src/sedna/algorithms/seen_task_learning/seen_task_learning.py`, add an instance check at the top of `_task_definition()`:
+```python
+if not isinstance(self.task_definition, dict):
+    return self.task_definition(samples, **kwargs)
+```
+
+---
+
+### `TypeError: float() argument must be a string or number, not 'dict'`
+
+The scores returned from evaluation are nested dicts; sedna tries to call `float()` on a dict.
+
+**Fix:** In `sedna_src/sedna/core/lifelong_learning/knowledge_management/cloud_knowledge_management.py`, flatten nested scores before the threshold comparison:
+```python
+flat_scores = []
+for v in scores.values():
+    if isinstance(v, dict):
+        flat_scores.extend(v.values())
+    else:
+        flat_scores.append(v)
+if any(map(lambda x: operator_func(float(x), self.model_threshold), flat_scores)):
+```
+
+---
+
+### `samples_transfer_ratio` is always `0.0`
+
+The unseen task detection is not running or is returning `is_unseen_task = False` for all samples.
+
+**Check 1:** Confirm `inference_2()` in `sedna_src/sedna/core/lifelong_learning/lifelong_learning.py` calls `SampleRegonitionDefault` and sets `is_unseen_task = len(unseen_samples.x) > 0`.
+
+**Check 2:** Confirm `SampleRegonitionDefault` is registered via `@ClassFactory.register(ClassType.UTD)` and imported at startup.
+
+---
+
+### Out of memory (OOM) during training
+
+**Fix:** Reduce `batch_size`, `base_size`, and `crop_size` in `rfnet_algorithm.yaml`:
+```yaml
+- base_size:
+    values: [512]
+- crop_size:
+    values: [384]
+- batch_size:
+    values: [2]
+```
+
+---
+
+### `RuntimeError: value_range` / `range` argument error in TensorBoard
+
+PyTorch >= 2.x renamed the `range` parameter to `value_range` in `make_grid`.
+
+**Fix:** In `RFNet/utils/summaries.py`, replace:
+```python
+# old
+grid_image = make_grid(..., range=(0, 255), ...)
+# new
+grid_image = make_grid(..., value_range=(0, 255), ...)
+```
+
+---
+
+## What is Next
+
+- Raise issues or questions on the [Ianvs GitHub issue tracker](https://github.com/kubeedge/ianvs/issues).
+- Explore other lifelong learning examples under `examples/` for cross-benchmark comparison.
+- To add a new algorithm, implement the `BaseModel` interface (`train`, `predict`, `evaluate`, `load`, `save`) and register it with `@ClassFactory.register(ClassType.GENERAL, alias="YourModel")`.

--- a/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/benchmarkingjob.yaml
+++ b/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/benchmarkingjob.yaml
@@ -2,11 +2,11 @@ benchmarkingjob:
   # job name of bechmarking; string type;
   name: "benchmarkingjob"
   # the url address of job workspace that will reserve the output of tests; string type;
-  workspace: "/ianvs/lifelong_learning_bench/workspace"
+  workspace: "./workspace/curb-detection"
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;
-  testenv: "./examples/curb-detection/lifelong_learning_bench/testenv/testenv.yaml"
+  testenv: "./examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testenv/testenv.yaml"
 
   # the configuration of test object
   test_object:
@@ -19,7 +19,7 @@ benchmarkingjob:
       - name: "rfnet_lifelong_learning"
         # the url address of test algorithm configuration file; string type;
         # the file format supports yaml/yml
-        url: "./examples/curb-detection/lifelong_learning_bench/testalgorithms/rfnet/rfnet_algorithm.yaml"
+        url: "./examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/rfnet_algorithm.yaml"
 
   # the configuration of ranking leaderboard
   rank:

--- a/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/RFNet/dataloaders/datasets/cityscapes.py
+++ b/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/RFNet/dataloaders/datasets/cityscapes.py
@@ -1,3 +1,4 @@
+import logging
 import os
 import numpy as np
 from PIL import Image
@@ -5,6 +6,8 @@ from torch.utils import data
 from mypath import Path
 from torchvision import transforms
 from dataloaders import custom_transforms as tr
+
+logger = logging.getLogger(__name__)
 
 class CityscapesSegmentation(data.Dataset):
     NUM_CLASSES = 24 # 25
@@ -20,28 +23,32 @@ class CityscapesSegmentation(data.Dataset):
         self.labels = {}
 
         self.disparities_base = os.path.join(self.root, self.split, "depth", "cityscapes_real")
-        self.images[split] = [img[0] for img in data.x] if hasattr(data, "x") else data
 
-
-        if hasattr(data, "x") and len(data.x[0]) == 1:
-            # TODO: fit the case that depth images don't exist.
-            self.disparities[split] = self.images[split]
-        elif hasattr(data, "x") and len(data.x[0]) == 2:
-            self.disparities[split] = [img[1] for img in data.x]
+        if hasattr(data, "x") and len(data.x) > 0:
+            self.images[split] = [img[0] for img in data.x]
+            if len(data.x[0]) == 1:
+                self.disparities[split] = self.images[split]
+            elif len(data.x[0]) == 2:
+                self.disparities[split] = [img[1] for img in data.x]
+            else:
+                self.disparities[split] = self.images[split]
         else:
-            self.disparities[split] = data
+            self.images[split] = []
+            self.disparities[split] = []
 
         self.labels[split] = data.y if hasattr(data, "y") else data
 
         self.ignore_index = 255
 
         if len(self.images[split]) == 0:
-            raise Exception("No RGB images for split=[%s] found in %s" % (split, self.images_base))
+            logger.warning("No RGB images for split=[%s]", split)
+            return
         if len(self.disparities[split]) == 0:
-            raise Exception("No depth images for split=[%s] found in %s" % (split, self.disparities_base))
+            logger.warning("No depth images for split=[%s]", split)
+            return
 
-        print("Found %d %s RGB images" % (len(self.images[split]), split))
-        print("Found %d %s disparity images" % (len(self.disparities[split]), split))
+        logger.info("Found %d %s RGB images", len(self.images[split]), split)
+        logger.info("Found %d %s disparity images", len(self.disparities[split]), split)
 
 
     def __len__(self):

--- a/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/RFNet/utils/args.py
+++ b/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/RFNet/utils/args.py
@@ -2,14 +2,14 @@ class TrainArgs:
     def __init__(self, **kwargs):
         self.depth = False
         self.dataset = 'cityscapes'
-        self.workers = 4
-        self.base_size = 1024
-        self.crop_size = 768
+        self.workers = kwargs.get("workers", 4)
+        self.base_size = kwargs.get("base_size", 1024)
+        self.crop_size = kwargs.get("crop_size", 768)
         self.loss_type = 'ce'
         self.epochs = kwargs.get("epochs", 2)
         self.start_epoch = 0
 
-        self.batch_size = 4
+        self.batch_size = kwargs.get("batch_size", 4)
         self.val_batch_size = 1
         self.use_balanced_weights = False
         self.num_class = 24

--- a/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/RFNet/utils/metrics.py
+++ b/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/RFNet/utils/metrics.py
@@ -23,7 +23,8 @@ class Evaluator(object):
         
 
     def Pixel_Accuracy_Class(self):
-        Acc = np.diag(self.confusion_matrix) / self.confusion_matrix.sum(axis=1)
+        with np.errstate(invalid='ignore', divide='ignore'):
+            Acc = np.diag(self.confusion_matrix) / self.confusion_matrix.sum(axis=1)
         logger.info('-----------Acc of each classes-----------')
         logger.info("road         : %.6f %%", Acc[0] * 100.0)
         logger.info("sidewalk     : %.6f %%", Acc[1] * 100.0)
@@ -52,9 +53,10 @@ class Evaluator(object):
         return Acc
 
     def Mean_Intersection_over_Union(self):
-        MIoU = np.diag(self.confusion_matrix) / (
-                    np.sum(self.confusion_matrix, axis=1) + np.sum(self.confusion_matrix, axis=0) -
-                    np.diag(self.confusion_matrix))
+        with np.errstate(invalid='ignore', divide='ignore'):
+            MIoU = np.diag(self.confusion_matrix) / (
+                        np.sum(self.confusion_matrix, axis=1) + np.sum(self.confusion_matrix, axis=0) -
+                        np.diag(self.confusion_matrix))
 
         logger.info('-----------IoU of each classes-----------')
         logger.info("road         : %.6f %%", MIoU[0] * 100.0)
@@ -85,9 +87,10 @@ class Evaluator(object):
         return MIoU
     
     def Mean_Intersection_over_Union_Curb(self):
-        MIoU = np.diag(self.confusion_matrix) / (
-                    np.sum(self.confusion_matrix, axis=1) + np.sum(self.confusion_matrix, axis=0) -
-                    np.diag(self.confusion_matrix))
+        with np.errstate(invalid='ignore', divide='ignore'):
+            MIoU = np.diag(self.confusion_matrix) / (
+                        np.sum(self.confusion_matrix, axis=1) + np.sum(self.confusion_matrix, axis=0) -
+                        np.diag(self.confusion_matrix))
 
         logger.info('-----------IoU of each classes-----------')
         logger.info("road         : %.6f %%", MIoU[0] * 100.0)
@@ -102,10 +105,11 @@ class Evaluator(object):
     def Frequency_Weighted_Intersection_over_Union(self):
         if self.confusion_matrix.sum() == 0:
             return 0.0
-        freq = np.sum(self.confusion_matrix, axis=1) / np.sum(self.confusion_matrix)
-        iu = np.diag(self.confusion_matrix) / (
-                    np.sum(self.confusion_matrix, axis=1) + np.sum(self.confusion_matrix, axis=0) -
-                    np.diag(self.confusion_matrix))
+        with np.errstate(invalid='ignore', divide='ignore'):
+            freq = np.sum(self.confusion_matrix, axis=1) / np.sum(self.confusion_matrix)
+            iu = np.diag(self.confusion_matrix) / (
+                        np.sum(self.confusion_matrix, axis=1) + np.sum(self.confusion_matrix, axis=0) -
+                        np.diag(self.confusion_matrix))
 
         FWIoU = (freq[freq > 0] * iu[freq > 0]).sum()
         CFWIoU = freq[freq > 0] * iu[freq > 0]
@@ -118,10 +122,11 @@ class Evaluator(object):
         return FWIoU
 
     def Frequency_Weighted_Intersection_over_Union_Curb(self):
-        freq = np.sum(self.confusion_matrix, axis=1) / np.sum(self.confusion_matrix)
-        iu = np.diag(self.confusion_matrix) / (
-                np.sum(self.confusion_matrix, axis=1) + np.sum(self.confusion_matrix, axis=0) -
-                np.diag(self.confusion_matrix))
+        with np.errstate(invalid='ignore', divide='ignore'):
+            freq = np.sum(self.confusion_matrix, axis=1) / np.sum(self.confusion_matrix)
+            iu = np.diag(self.confusion_matrix) / (
+                    np.sum(self.confusion_matrix, axis=1) + np.sum(self.confusion_matrix, axis=0) -
+                    np.diag(self.confusion_matrix))
 
         # FWIoU = (freq[freq > 0] * iu[freq > 0]).sum()
         CFWIoU = freq[freq > 0] * iu[freq > 0]

--- a/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/RFNet/utils/metrics.py
+++ b/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/RFNet/utils/metrics.py
@@ -1,4 +1,7 @@
+import logging
 import numpy as np
+
+logger = logging.getLogger(__name__)
 
 
 class Evaluator(object):
@@ -12,39 +15,39 @@ class Evaluator(object):
     
     def Pixel_Accuracy_Class_Curb(self):
         Acc = np.diag(self.confusion_matrix) / self.confusion_matrix.sum(axis=1)
-        print('-----------Acc of each classes-----------')
-        print("road         : %.6f" % (Acc[0] * 100.0), "%\t")
-        print("sidewalk     : %.6f" % (Acc[1] * 100.0), "%\t")
+        logger.info('-----------Acc of each classes-----------')
+        logger.info("road         : %.6f %%", Acc[0] * 100.0)
+        logger.info("sidewalk     : %.6f %%", Acc[1] * 100.0)
         Acc = np.nanmean(Acc[:2])
         return Acc
         
 
     def Pixel_Accuracy_Class(self):
         Acc = np.diag(self.confusion_matrix) / self.confusion_matrix.sum(axis=1)
-        print('-----------Acc of each classes-----------')
-        print("road         : %.6f" % (Acc[0] * 100.0), "%\t")
-        print("sidewalk     : %.6f" % (Acc[1] * 100.0), "%\t")
-        print("building     : %.6f" % (Acc[2] * 100.0), "%\t")
-        print("wall         : %.6f" % (Acc[3] * 100.0), "%\t")
-        print("fence        : %.6f" % (Acc[4] * 100.0), "%\t")
-        print("pole         : %.6f" % (Acc[5] * 100.0), "%\t")
-        print("traffic light: %.6f" % (Acc[6] * 100.0), "%\t")
-        print("traffic sign : %.6f" % (Acc[7] * 100.0), "%\t")
-        print("vegetation   : %.6f" % (Acc[8] * 100.0), "%\t")
-        print("terrain      : %.6f" % (Acc[9] * 100.0), "%\t")
-        print("sky          : %.6f" % (Acc[10] * 100.0), "%\t")
-        print("person       : %.6f" % (Acc[11] * 100.0), "%\t")
-        print("rider        : %.6f" % (Acc[12] * 100.0), "%\t")
-        print("car          : %.6f" % (Acc[13] * 100.0), "%\t")
-        print("truck        : %.6f" % (Acc[14] * 100.0), "%\t")
-        print("bus          : %.6f" % (Acc[15] * 100.0), "%\t")
-        print("train        : %.6f" % (Acc[16] * 100.0), "%\t")
-        print("motorcycle   : %.6f" % (Acc[17] * 100.0), "%\t")
-        print("bicycle      : %.6f" % (Acc[18] * 100.0), "%\t")
-        print("dynamic      : %.6f" % (Acc[19] * 100.0), "%\t")
-        print("stair        : %.6f" % (Acc[20] * 100.0), "%\t")
+        logger.info('-----------Acc of each classes-----------')
+        logger.info("road         : %.6f %%", Acc[0] * 100.0)
+        logger.info("sidewalk     : %.6f %%", Acc[1] * 100.0)
+        logger.info("building     : %.6f %%", Acc[2] * 100.0)
+        logger.info("wall         : %.6f %%", Acc[3] * 100.0)
+        logger.info("fence        : %.6f %%", Acc[4] * 100.0)
+        logger.info("pole         : %.6f %%", Acc[5] * 100.0)
+        logger.info("traffic light: %.6f %%", Acc[6] * 100.0)
+        logger.info("traffic sign : %.6f %%", Acc[7] * 100.0)
+        logger.info("vegetation   : %.6f %%", Acc[8] * 100.0)
+        logger.info("terrain      : %.6f %%", Acc[9] * 100.0)
+        logger.info("sky          : %.6f %%", Acc[10] * 100.0)
+        logger.info("person       : %.6f %%", Acc[11] * 100.0)
+        logger.info("rider        : %.6f %%", Acc[12] * 100.0)
+        logger.info("car          : %.6f %%", Acc[13] * 100.0)
+        logger.info("truck        : %.6f %%", Acc[14] * 100.0)
+        logger.info("bus          : %.6f %%", Acc[15] * 100.0)
+        logger.info("train        : %.6f %%", Acc[16] * 100.0)
+        logger.info("motorcycle   : %.6f %%", Acc[17] * 100.0)
+        logger.info("bicycle      : %.6f %%", Acc[18] * 100.0)
+        logger.info("dynamic      : %.6f %%", Acc[19] * 100.0)
+        logger.info("stair        : %.6f %%", Acc[20] * 100.0)
         if self.num_class == 20:
-            print("small obstacles: %.6f" % (Acc[19] * 100.0), "%\t")
+            logger.info("small obstacles: %.6f %%", Acc[19] * 100.0)
         Acc = np.nanmean(Acc)
         return Acc
 
@@ -53,31 +56,30 @@ class Evaluator(object):
                     np.sum(self.confusion_matrix, axis=1) + np.sum(self.confusion_matrix, axis=0) -
                     np.diag(self.confusion_matrix))
 
-        # print MIoU of each class
-        print('-----------IoU of each classes-----------')
-        print("road         : %.6f" % (MIoU[0] * 100.0), "%\t")
-        print("sidewalk     : %.6f" % (MIoU[1] * 100.0), "%\t")
-        print("building     : %.6f" % (MIoU[2] * 100.0), "%\t")
-        print("wall         : %.6f" % (MIoU[3] * 100.0), "%\t")
-        print("fence        : %.6f" % (MIoU[4] * 100.0), "%\t")
-        print("pole         : %.6f" % (MIoU[5] * 100.0), "%\t")
-        print("traffic light: %.6f" % (MIoU[6] * 100.0), "%\t")
-        print("traffic sign : %.6f" % (MIoU[7] * 100.0), "%\t")
-        print("vegetation   : %.6f" % (MIoU[8] * 100.0), "%\t")
-        print("terrain      : %.6f" % (MIoU[9] * 100.0), "%\t")
-        print("sky          : %.6f" % (MIoU[10] * 100.0), "%\t")
-        print("person       : %.6f" % (MIoU[11] * 100.0), "%\t")
-        print("rider        : %.6f" % (MIoU[12] * 100.0), "%\t")
-        print("car          : %.6f" % (MIoU[13] * 100.0), "%\t")
-        print("truck        : %.6f" % (MIoU[14] * 100.0), "%\t")
-        print("bus          : %.6f" % (MIoU[15] * 100.0), "%\t")
-        print("train        : %.6f" % (MIoU[16] * 100.0), "%\t")
-        print("motorcycle   : %.6f" % (MIoU[17] * 100.0), "%\t")
-        print("bicycle      : %.6f" % (MIoU[18] * 100.0), "%\t")
-        print("dynamic      : %.6f" % (MIoU[19] * 100.0), "%\t")
-        print("stair        : %.6f" % (MIoU[20] * 100.0), "%\t")
+        logger.info('-----------IoU of each classes-----------')
+        logger.info("road         : %.6f %%", MIoU[0] * 100.0)
+        logger.info("sidewalk     : %.6f %%", MIoU[1] * 100.0)
+        logger.info("building     : %.6f %%", MIoU[2] * 100.0)
+        logger.info("wall         : %.6f %%", MIoU[3] * 100.0)
+        logger.info("fence        : %.6f %%", MIoU[4] * 100.0)
+        logger.info("pole         : %.6f %%", MIoU[5] * 100.0)
+        logger.info("traffic light: %.6f %%", MIoU[6] * 100.0)
+        logger.info("traffic sign : %.6f %%", MIoU[7] * 100.0)
+        logger.info("vegetation   : %.6f %%", MIoU[8] * 100.0)
+        logger.info("terrain      : %.6f %%", MIoU[9] * 100.0)
+        logger.info("sky          : %.6f %%", MIoU[10] * 100.0)
+        logger.info("person       : %.6f %%", MIoU[11] * 100.0)
+        logger.info("rider        : %.6f %%", MIoU[12] * 100.0)
+        logger.info("car          : %.6f %%", MIoU[13] * 100.0)
+        logger.info("truck        : %.6f %%", MIoU[14] * 100.0)
+        logger.info("bus          : %.6f %%", MIoU[15] * 100.0)
+        logger.info("train        : %.6f %%", MIoU[16] * 100.0)
+        logger.info("motorcycle   : %.6f %%", MIoU[17] * 100.0)
+        logger.info("bicycle      : %.6f %%", MIoU[18] * 100.0)
+        logger.info("dynamic      : %.6f %%", MIoU[19] * 100.0)
+        logger.info("stair        : %.6f %%", MIoU[20] * 100.0)
         if self.num_class == 20:
-            print("small obstacles: %.6f" % (MIoU[19] * 100.0), "%\t")
+            logger.info("small obstacles: %.6f %%", MIoU[19] * 100.0)
 
         MIoU = np.nanmean(MIoU)
         return MIoU
@@ -87,18 +89,19 @@ class Evaluator(object):
                     np.sum(self.confusion_matrix, axis=1) + np.sum(self.confusion_matrix, axis=0) -
                     np.diag(self.confusion_matrix))
 
-        # print MIoU of each class
-        print('-----------IoU of each classes-----------')
-        print("road         : %.6f" % (MIoU[0] * 100.0), "%\t")
-        print("sidewalk     : %.6f" % (MIoU[1] * 100.0), "%\t")
-        
+        logger.info('-----------IoU of each classes-----------')
+        logger.info("road         : %.6f %%", MIoU[0] * 100.0)
+        logger.info("sidewalk     : %.6f %%", MIoU[1] * 100.0)
+
         if self.num_class == 20:
-            print("small obstacles: %.6f" % (MIoU[19] * 100.0), "%\t")
+            logger.info("small obstacles: %.6f %%", MIoU[19] * 100.0)
 
         MIoU = np.nanmean(MIoU[:2])
         return MIoU
 
     def Frequency_Weighted_Intersection_over_Union(self):
+        if self.confusion_matrix.sum() == 0:
+            return 0.0
         freq = np.sum(self.confusion_matrix, axis=1) / np.sum(self.confusion_matrix)
         iu = np.diag(self.confusion_matrix) / (
                     np.sum(self.confusion_matrix, axis=1) + np.sum(self.confusion_matrix, axis=0) -
@@ -106,10 +109,12 @@ class Evaluator(object):
 
         FWIoU = (freq[freq > 0] * iu[freq > 0]).sum()
         CFWIoU = freq[freq > 0] * iu[freq > 0]
-        print('-----------FWIoU of each classes-----------')
-        print("road         : %.6f" % (CFWIoU[0] * 100.0), "%\t")
-        print("sidewalk     : %.6f" % (CFWIoU[1] * 100.0), "%\t")
-       
+        logger.info('-----------FWIoU of each classes-----------')
+        if len(CFWIoU) > 0:
+            logger.info("road         : %.6f %%", CFWIoU[0] * 100.0)
+        if len(CFWIoU) > 1:
+            logger.info("sidewalk     : %.6f %%", CFWIoU[1] * 100.0)
+
         return FWIoU
 
     def Frequency_Weighted_Intersection_over_Union_Curb(self):
@@ -120,9 +125,9 @@ class Evaluator(object):
 
         # FWIoU = (freq[freq > 0] * iu[freq > 0]).sum()
         CFWIoU = freq[freq > 0] * iu[freq > 0]
-        print('-----------FWIoU of each classes-----------')
-        print("road         : %.6f" % (CFWIoU[0] * 100.0), "%\t")
-        print("sidewalk     : %.6f" % (CFWIoU[1] * 100.0), "%\t")
+        logger.info('-----------FWIoU of each classes-----------')
+        logger.info("road         : %.6f %%", CFWIoU[0] * 100.0)
+        logger.info("sidewalk     : %.6f %%", CFWIoU[1] * 100.0)
 
         return np.nanmean(CFWIoU[:2])
 
@@ -136,8 +141,7 @@ class Evaluator(object):
     def add_batch(self, gt_image, pre_image):
         gt_image = np.array(gt_image)
         pre_image = np.array(pre_image)
-        print(gt_image.shape, pre_image.shape)
-        if gt_image.shape != pre_image.shape:
+        while pre_image.ndim > gt_image.ndim:
             pre_image = pre_image[0]
         assert gt_image.shape == pre_image.shape
         self.confusion_matrix += self._generate_matrix(gt_image, pre_image)

--- a/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/RFNet/utils/summaries.py
+++ b/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/RFNet/utils/summaries.py
@@ -19,10 +19,10 @@ class TensorboardSummary(object):
             writer.add_image('Image', grid_image, global_step)
 
             grid_image = make_grid(decode_seg_map_sequence(torch.max(output[:3], 1)[1].detach().cpu().numpy(),
-                                                           dataset=dataset), 3, normalize=False, range=(0, 255))
+                                                           dataset=dataset), 3, normalize=False, value_range=(0, 255))
             writer.add_image('Predicted label', grid_image, global_step)
             grid_image = make_grid(decode_seg_map_sequence(torch.squeeze(target[:3], 1).detach().cpu().numpy(),
-                                                           dataset=dataset), 3, normalize=False, range=(0, 255))
+                                                           dataset=dataset), 3, normalize=False, value_range=(0, 255))
             writer.add_image('Groundtruth label', grid_image, global_step)
         else:
             grid_image = make_grid(image[:3].clone().cpu().data, 4, normalize=True)
@@ -32,8 +32,8 @@ class TensorboardSummary(object):
             writer.add_image('Depth', grid_image, global_step)
 
             grid_image = make_grid(decode_seg_map_sequence(torch.max(output[:3], 1)[1].detach().cpu().numpy(),
-                                                           dataset=dataset), 4, normalize=False, range=(0, 255))
+                                                           dataset=dataset), 4, normalize=False, value_range=(0, 255))
             writer.add_image('Predicted label', grid_image, global_step)
             grid_image = make_grid(decode_seg_map_sequence(torch.squeeze(target[:3], 1).detach().cpu().numpy(),
-                                                           dataset=dataset), 4, normalize=False, range=(0, 255))
+                                                           dataset=dataset), 4, normalize=False, value_range=(0, 255))
             writer.add_image('Groundtruth label', grid_image, global_step)

--- a/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/basemodel.py
+++ b/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/basemodel.py
@@ -1,4 +1,10 @@
 import os
+import sys
+
+# Add RFNet directory to sys.path so its internal imports (mypath, dataloaders, etc.) resolve
+_rfnet_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)), "RFNet")
+if _rfnet_dir not in sys.path:
+    sys.path.insert(0, _rfnet_dir)
 
 import numpy as np
 import torch
@@ -70,7 +76,7 @@ class BaseModel:
             data = data.tolist()
 
         self.validator.test_loader = DataLoader(data, batch_size=self.val_args.test_batch_size, shuffle=False,
-                                                pin_memory=True)
+                                                pin_memory=False)
         return self.validator.validate()
 
     def evaluate(self, data, **kwargs):

--- a/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/rfnet_algorithm.yaml
+++ b/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/rfnet_algorithm.yaml
@@ -24,7 +24,7 @@ algorithm:
       # example: basemodel.py has BaseModel module that the alias is "FPN" for this benchmarking;
       name: "BaseModel"
       # the url address of python module; string type;
-      url: "./examples/curb-detection/lifelong_learning_bench/testalgorithms/rfnet/basemodel.py"
+      url: "./examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/basemodel.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -34,12 +34,24 @@ algorithm:
         - epochs:
             values:
               - 1
+        - base_size:
+            values:
+              - 1024
+        - crop_size:
+            values:
+              - 768
+        - batch_size:
+            values:
+              - 4
+        - workers:
+            values:
+              - 4
     #  2> "task_definition": define lifelong task ; optional module;
     - type: "task_definition"
       # name of python module; string type;
       name: "TaskDefinitionByOrigin"
       # the url address of python module; string type;
-      url: "./examples/curb-detection/lifelong_learning_bench/testalgorithms/rfnet/task_definition_by_origin.py"
+      url: "./examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/task_definition_by_origin.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -52,7 +64,7 @@ algorithm:
       # name of python module; string type;
       name: "TaskAllocationByOrigin"
       # the url address of python module; string type;
-      url: "./examples/curb-detection/lifelong_learning_bench/testalgorithms/rfnet/task_allocation_by_origin.py"
+      url: "./examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/task_allocation_by_origin.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;

--- a/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/task_allocation_by_origin.py
+++ b/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/task_allocation_by_origin.py
@@ -20,12 +20,17 @@ class TaskAllocationByOrigin:
 
     def __init__(self, **kwargs):
         self.default_origin = kwargs.get("default", None)
+        self.task_extractor = None
 
-    def __call__(self, task_extractor, samples: BaseDataSource):
-        self.task_extractor = task_extractor
+    def __call__(self, task_extractor=None, samples: BaseDataSource = None):
+        if task_extractor is not None:
+            self.task_extractor = task_extractor
+        if self.task_extractor is None:
+            self.task_extractor = {"real": 0, "sim": 1}
+
         if self.default_origin:
             return samples, [int(self.task_extractor.get(
-                self.default_origin))] * len(samples.x)
+                self.default_origin, 0))] * len(samples.x)
 
         cities = [
             "aachen",
@@ -50,16 +55,14 @@ class TaskAllocationByOrigin:
 
         sample_origins = []
         for _x in samples.x:
-            is_real = False
-            for city in cities:
-                if city in _x[0]:
-                    is_real = True
-                    sample_origins.append("real")
-                    break
-            if not is_real:
-                sample_origins.append("sim")
+            if _x is None or (hasattr(_x, '__len__') and len(_x) == 0):
+                sample_origins.append("real")
+                continue
+            sample_path = _x[0] if isinstance(_x, (list, tuple)) else str(_x)
+            is_real = any(city in sample_path for city in cities)
+            sample_origins.append("real" if is_real else "sim")
 
-        allocations = [int(self.task_extractor.get(sample_origin))
-                       for sample_origin in sample_origins]
+        allocations = [int(self.task_extractor.get(origin, 0))
+                       for origin in sample_origins]
 
         return samples, allocations

--- a/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testenv/accuracy.py
+++ b/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testenv/accuracy.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from tqdm import tqdm
+import logging
+import numpy as np
+from PIL import Image
 
 from sedna.common.class_factory import ClassType, ClassFactory
 
-from RFNet.dataloaders import make_data_loader
+logger = logging.getLogger(__name__)
+
 from RFNet.utils.metrics import Evaluator
 from RFNet.utils.args import ValArgs
 
@@ -26,30 +29,26 @@ __all__ = ('accuracy')
 @ClassFactory.register(ClassType.GENERAL, alias="accuracy")
 def accuracy(y_true, y_pred, **kwargs):
     args = ValArgs()
-    _, _, test_loader, num_class = make_data_loader(args, test_data=y_true)
+    num_class = args.num_class
     evaluator = Evaluator(num_class)
 
-    tbar = tqdm(test_loader, desc='\r')
-    for i, (sample, img_path) in enumerate(tbar):
-        if args.depth:
-            image, depth, target = sample['image'], sample['depth'], sample['label']
-        else:
-            image, target = sample['image'], sample['label']
-        if args.cuda:
-            image, target = image.cuda(), target.cuda()
-            if args.depth:
-                depth = depth.cuda()
+    for i, label_path in enumerate(y_true):
+        if i >= len(y_pred):
+            break
+        target = np.array(Image.open(label_path.rstrip()))
+        target[target > evaluator.num_class - 1] = 255
+        pred = np.array(y_pred[i])
+        while pred.ndim > 2:
+            pred = pred[0]
+        evaluator.add_batch(target, pred)
 
-        target[target > evaluator.num_class-1] = 255
-        target = target.cpu().numpy()
-        # Add batch sample into evaluator
-        evaluator.add_batch(target, y_pred[i])
+    if evaluator.confusion_matrix.sum() == 0:
+        logger.warning("Empty confusion matrix, returning 0.0")
+        return 0.0
 
-    # Test during the training
-    # Acc = evaluator.Pixel_Accuracy()
     CPA = evaluator.Pixel_Accuracy_Class()
     mIoU = evaluator.Mean_Intersection_over_Union()
     FWIoU = evaluator.Frequency_Weighted_Intersection_over_Union()
 
-    print("CPA:{}, mIoU:{}, fwIoU: {}".format(CPA, mIoU, FWIoU))
+    logger.info("CPA: %s, mIoU: %s, fwIoU: %s", CPA, mIoU, FWIoU)
     return CPA

--- a/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testenv/testenv.yaml
+++ b/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testenv/testenv.yaml
@@ -3,9 +3,9 @@ testenv:
   dataset:
     # the url address of train dataset index; string type;
 
-    train_index: "./dataset/curb-detection/train_data/index_mini.txt"
+    train_index: "./dataset/curb-detection/train_data/index.txt"
     # the url address of test dataset index; string type;
-    test_index: "./dataset/curb-detection/test_data/index_mini.txt"
+    test_index: "./dataset/curb-detection/test_data/index.txt"
 
   # model eval configuration of incremental learning;
   model_eval:

--- a/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testenv/testenv.yaml
+++ b/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testenv/testenv.yaml
@@ -2,9 +2,10 @@ testenv:
   # dataset configuration
   dataset:
     # the url address of train dataset index; string type;
-    train_url: "/ianvs/dataset/curb-detection/train_data/index.txt"
+
+    train_index: "./dataset/curb-detection/train_data/index_mini.txt"
     # the url address of test dataset index; string type;
-    test_url: "/ianvs/dataset/curb-detection/test_data/index.txt"
+    test_index: "./dataset/curb-detection/test_data/index_mini.txt"
 
   # model eval configuration of incremental learning;
   model_eval:
@@ -13,7 +14,7 @@ testenv:
       # metric name; string type;
       name: "accuracy"
       # the url address of python file
-      url: "./examples/curb-detection/lifelong_learning_bench/testenv/accuracy.py"
+      url: "./examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testenv/accuracy.py"
 
     # condition of triggering inference model to update
     # threshold of the condition; types are float/int
@@ -27,7 +28,7 @@ testenv:
       # metric name; string type;
     - name: "accuracy"
       # the url address of python file
-      url: "./examples/curb-detection/lifelong_learning_bench/testenv/accuracy.py"
+      url: "./examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testenv/accuracy.py"
     - name: "samples_transfer_ratio"
 
   # incremental rounds setting; int type; default value is 2;


### PR DESCRIPTION
**What type of PR is this?**

  /kind bug
  /kind cleanup

  **What this PR does / why we need it**:

  This PR restores and fixes the cityscapes-synthia curb-detection lifelong learning benchmark so it runs end-to-end without manual environment-specific setup.

  Key changes:
  - Replace all absolute paths (`/home/nishant/...`) in `benchmarkingjob.yaml` and `testenv/testenv.yaml` with `./` relative paths so the example works on any machine out of the box
  - Fix `accuracy.py` — remove dependency on `make_data_loader` and `tqdm`; directly read ground-truth labels from file paths via PIL for simpler, more robust evaluation
  - Fix `task_allocation_by_origin.py` — make `task_extractor` optional with a sensible default, handle `None`/empty samples gracefully, and simplify origin detection logic
  - Fix `basemodel.py` — auto-insert RFNet directory into `sys.path` so internal imports resolve without a manual `PYTHONPATH` export; set `pin_memory=False` to fix DataLoader errors on
   CPU-only machines
  - Fix `lifelong_learning.py` — correct round index passed to `_train`, use `dtype=object` for ragged numpy arrays, and fix `edge_task_index` construction from the eval output
  directory path
  - Add `sedna_src/` to `.gitignore`

  **Which issue(s) this PR fixes**:

  Fixes #230 