### PR TITLE
fix: add missing colorlog and pyyaml dependencies to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,5 @@ pandas
 tqdm
 matplotlib
 onnx
+colorlog>=6.0.0
+pyyaml>=6.0.0


### PR DESCRIPTION
/kind bug

Fresh install via `pip install -r requirements.txt` && `pip install -e .`
causes `ianvs --help` to immediately fail:

* ModuleNotFoundError: No module named 'colorlog'
* ModuleNotFoundError: No module named 'yaml'

Both `colorlog` and `pyyaml` are used in core runtime modules but were
missing from `requirements.txt`, blocking new contributors from running
ianvs on a fresh setup.

This PR adds both missing dependencies to fix the issue.

Fixes #413

