### PR TITLE
fix: synchronize Ianvs version references to v0.3.0

### DIFF
--- a/core/__version__.py
+++ b/core/__version__.py
@@ -16,7 +16,7 @@
 
 # follow Semantic Versioning (https://semver.org/)
 _MAJOR_V = '0'
-_MINOR_V = '1'
+_MINOR_V = '3'
 _PATCH_V = '0'
 
 __version__ = '.'.join([_MAJOR_V, _MINOR_V, _PATCH_V])

--- a/docs/user_interface/how-to-use-ianvs-command-line.md
+++ b/docs/user_interface/how-to-use-ianvs-command-line.md
@@ -27,7 +27,7 @@ For example:
 
 ```shell
 $ ianvs -v
-0.1.0
+0.3.0
 ```
 
 ### Run a benchmarking job

--- a/examples/imagenet/multiedge_inference_bench/requirements.txt
+++ b/examples/imagenet/multiedge_inference_bench/requirements.txt
@@ -24,7 +24,7 @@ h11==0.14.0
 h5py==3.8.0
 huggingface-hub==0.16.4
 humanfriendly==10.0
-ianvs==0.1.0
+ianvs>=0.3.0
 idna==3.7
 imageio==2.31.2
 importlib-metadata==6.7.0

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ class InstallPrepare:
 
     @property
     def version(self):
-        default_version = "0.1.0"
+        default_version = "0.3.0"
         return default_version
 
     @property


### PR DESCRIPTION
/kind bug
/kind documentation

**What type of PR is this?**

This PR fixes version inconsistencies across the repository by synchronizing Ianvs version references with the latest release (`v0.3.0`).

**What this PR does / why we need it**:

The repository still contains multiple outdated references to Ianvs `v0.1.0` while the latest released version is `v0.3.0`.

This PR updates:

* Core version definition to `0.3.0`
* Package version in `setup.py`
* CLI version documentation
* Example requirements that reference Ianvs

These changes ensure consistency between the released package, CLI output, documentation, and example dependencies.

**Which issue(s) this PR fixes**:

N/A
