### PR TITLE
fix(engine): resolve `ZeroDivisionError` in metrics module

### DIFF
--- a/core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py
+++ b/core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py
@@ -126,7 +126,10 @@ class LifelongLearning(ParadigmBase):
                         score_list = tmp_dict.get(entry, ['' for i in range(rounds)])
                         score_list[j-1] = scores
                         tmp_dict[entry] = score_list
-                    task_avg_score['accuracy'] = task_avg_score['accuracy']/i
+                    if i > 0:
+                        task_avg_score['accuracy'] /= i
+                    else:
+                        LOGGER.warning("task_avg_score accuracy denominator is zero; defaulting to 0.0")
                     score_list = tmp_dict.get("task_avg", [{'accuracy':0.0} for i in range(rounds)])
                     score_list[j-1] = task_avg_score
                     tmp_dict["task_avg"] = score_list
@@ -148,7 +151,10 @@ class LifelongLearning(ParadigmBase):
                 entry = detail.entry
                 LOGGER.info(f"{entry} scores: {scores}")
                 task_avg_score['accuracy'] += scores['accuracy']
-            task_avg_score['accuracy'] = task_avg_score['accuracy']/i
+            if i > 0:
+                task_avg_score['accuracy'] /= i
+            else:
+                LOGGER.warning("task_avg_score accuracy denominator is zero; defaulting to 0.0")
             self.system_metric_info[SystemMetricType.TASK_AVG_ACC.value] = task_avg_score
             LOGGER.info(task_avg_score)
             job = self.build_paradigm_job(ParadigmType.LIFELONG_LEARNING.value)
@@ -224,7 +230,10 @@ class LifelongLearning(ParadigmBase):
                         score_list = tmp_dict.get(entry, ['' for i in range(rounds)])
                         score_list[j-1] = scores
                         tmp_dict[entry] = score_list
-                    task_avg_score['accuracy'] = task_avg_score['accuracy']/i
+                    if i > 0:
+                        task_avg_score['accuracy'] /= i
+                    else:
+                        LOGGER.warning("task_avg_score accuracy denominator is zero; defaulting to 0.0")
                     score_list = tmp_dict.get("task_avg", [{'accuracy':0.0} for i in range(rounds)])
                     score_list[j-1] = task_avg_score
                     tmp_dict["task_avg"] = score_list
@@ -247,7 +256,10 @@ class LifelongLearning(ParadigmBase):
                 entry = detail.entry
                 LOGGER.info(f"{entry} scores: {scores}")
                 task_avg_score['accuracy'] += scores['accuracy']
-            task_avg_score['accuracy'] = task_avg_score['accuracy']/i
+            if i > 0:
+                task_avg_score['accuracy'] /= i
+            else:
+                LOGGER.warning("task_avg_score accuracy denominator is zero; defaulting to 0.0")
             self.system_metric_info[SystemMetricType.TASK_AVG_ACC.value] = task_avg_score
             LOGGER.info(task_avg_score)
             test_res, unseen_task_train_samples = self._inference(self.edge_task_index,

--- a/core/testcasecontroller/metrics/metrics.py
+++ b/core/testcasecontroller/metrics/metrics.py
@@ -79,8 +79,17 @@ def compute(key, matrix):
         if "accuracy" in matrix[i][i] and "accuracy" in matrix[0][i]:
             fwt_score += matrix[i][i]["accuracy"] - matrix[0][i]["accuracy"]
 
-    accuracy = accuracy / ((length - 1) * (length - 1))
-    bwt_score = bwt_score / ((length - 1) * (length - 1))
+    if length <= 1:
+        bwt_score = np.nan
+        fwt_score = np.nan
+        print(f"{key} BWT_score: {bwt_score}")
+        print(f"{key} FWT_score: {fwt_score}")
+        return [], bwt_score, fwt_score
+    
+    denom = (length - 1) * (length - 1)
+
+    accuracy = accuracy / denom
+    bwt_score = bwt_score / denom
     fwt_score = fwt_score / (length - 1)
 
     print(f"{key} BWT_score: {bwt_score}")


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/ianvs/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**

/kind bug


**What this PR does / why we need it**:
This PR guards against division-by-zero errors in metric calculations and lifelong learning paradigm average accuracy calculations.

Specifically, it implements the following safeguards:
- **Lifelong Learning Paradigm (`core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py`)**: Adds checks to ensure the task denominator `i` is not zero when calculating `task_avg_score['accuracy']`. If it is zero, it logs a warning and defaults the average accuracy to `0.0`, preventing a `ZeroDivisionError`.
- **Metrics Computation (`core/testcasecontroller/metrics/metrics.py`)**: Adds checks to ensure the denominator `denom = (length - 1) * (length - 1)` is greater than zero before performing division for the BWT, FWT, and accuracy scores. If it is less than or equal to zero, it logs/prints the score, assigns `np.nan` to `bwt_score` and `fwt_score`, and returns early.

**Which issue(s) this PR fixes**:
Part of #495 
