### PR TITLE
fix(engine): standardize workspace path portability

### DIFF
--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/utils/saver.py
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/utils/saver.py
@@ -10,7 +10,17 @@ class Saver(object):
 
     def __init__(self, args):
         self.args = args
-        self.directory = os.path.join('/tmp', args.dataset, args.checkname)
+        
+        # Secure Path Resolution
+        dataset = args.dataset or ""
+        checkname = args.checkname or ""
+        workspace_tmp = os.path.abspath(os.path.join(os.getcwd(), 'tmp'))
+        directory = os.path.abspath(os.path.join(workspace_tmp, dataset, checkname))
+        
+        if not directory.startswith(workspace_tmp):
+            raise ValueError("Path traversal detected: directory is outside the workspace.")
+        self.directory = directory
+        
         self.runs = sorted(glob.glob(os.path.join(self.directory, 'experiment_*')))
         run_id = int(self.runs[-1].split('_')[-1]) + 1 if self.runs else 0
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/ianvs/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
This PR standardizes workspace directory resolution within the `Saver` utility, replacing hardcoded system paths (e.g., `/tmp`) with relative paths (`os.getcwd()`). This ensures that checkpoint directories are portable and can execute seamlessly across diverse developer environments and operating systems without permission errors or path conflicts.

**Which issue(s) this PR fixes**:
Part of #495

**Special notes for your reviewer**:
This PR is part of the core stability audit for Ianvs. The changes ensure that the `Saver` module correctly routes workspace-specific output to the local project environment.