### PR TITLE
fix(engine): sanitize NaN values in leaderboard output

### DIFF
--- a/core/storymanager/rank/rank.py
+++ b/core/storymanager/rank/rank.py
@@ -188,7 +188,8 @@ class Rank:
         # pylint: disable=E1101
         all_df = copy.deepcopy(self.all_df)
         all_df.index = np.arange(1, len(all_df) + 1)
-        all_df.to_csv(self.all_rank_file, index_label="rank", encoding="utf-8")
+        all_df.to_csv(self.all_rank_file, index_label="rank", encoding="utf-8", na_rep="N/A")
+
 
     def _get_selected(self, test_cases, test_results) -> pd.DataFrame:
         module_types = self.selected_dataitem.get("modules")
@@ -228,7 +229,9 @@ class Rank:
         # pylint: disable=E1101
         selected_df = self._get_selected(test_cases, test_results)
         selected_df.index = np.arange(1, len(selected_df) + 1)
-        selected_df.to_csv(self.selected_rank_file, index_label="rank", encoding="utf-8")
+        selected_df.to_csv(
+            self.selected_rank_file, index_label="rank", encoding="utf-8", na_rep="N/A"
+        )
 
     def _draw_pictures(self, test_cases, test_results):
         # pylint: disable=E1101


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR sanitizes `NaN` values during the leaderboard generation process by filling them with "N/A" strings in the resulting CSV output. This prevents invalid or uninitialized metric records from causing downstream display or parsing errors when compiling the final markdown leaderboard.

**Which issue(s) this PR fixes**:
Part of #495

**Special notes for your reviewer**:
This PR is part of the core stability audit for Ianvs. By explicitly handling `NaN` values in `rank.py`, we ensure the generated rank reports are cleaner and more resilient to edge cases where metrics might fail to initialize.