### PR TITLE
fix(examples): align MOT17 config paths and dataset indexing

### DIFF
--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testalgorithms/tracking/byte_track/byte_track_algorithm.yaml
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testalgorithms/tracking/byte_track/byte_track_algorithm.yaml
@@ -17,7 +17,7 @@ algorithm:
       # example: basemodel.py has BaseModel module that the alias is "FPN" for this benchmarking;
       name: "ByteTrack"
       # the url address of python module; string type;
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testalgorithms/tracking/byte_track/basemodel.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testalgorithms/tracking/byte_track/basemodel.py"
 
       # hyperparameters configuration for the python module; list type;
       hyperparameters:

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/testenv.yaml
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/testenv.yaml
@@ -2,9 +2,9 @@ testenv:
   # dataset configuration
   dataset:
     # the url address of train dataset index; string type;
-    train_url: "./dataset/mot17/annotations/train_half.json"
+    train_index: "./dataset/mot17/annotations/train_half.json"
     # the url address of test dataset index; string type;
-    test_url: "./dataset/mot17/annotations/val_half.json"
+    test_index: "./dataset/mot17/annotations/val_half.json"
 
   # metrics configuration for test case's evaluation; list type;
   metrics:

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/testenv.yaml
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/testenv.yaml
@@ -11,19 +11,19 @@ testenv:
       # metric name; string type;
     - name: "recall"
       # the url address of python file
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testenv/tracking/recall.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/recall.py"
     - name: "precision"
       # the url address of python file
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testenv/tracking/precision.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/precision.py"
     - name: "f1_score"
       # the url address of python file
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testenv/tracking/f1_score.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/f1_score.py"
     - name: "mota"
       # the url address of python file
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testenv/tracking/mota.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/mota.py"
     - name: "motp"
       # the url address of python file
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testenv/tracking/motp.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/motp.py"
     - name: "idf1"
       # the url address of python file
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testenv/tracking/idf1.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/idf1.py"

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/tracking_job.yaml
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/tracking_job.yaml
@@ -2,11 +2,11 @@ benchmarkingjob:
   # job name of benchmarking; string type;
   name: "tracking_job"
   # the url address of job workspace that will reserve the output of tests; string type;
-  workspace: "/ianvs/multiedge_inference_bench/workspace"
+  workspace: "./ianvs-workspace/mot17/multiedge_inference_bench"
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;
-  testenv: "./examples/pedestrian_tracking/multiedge_inference_bench/testenv/tracking/testenv.yaml"
+  testenv: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/testenv.yaml"
 
   # the configuration of test object
   test_object:
@@ -19,7 +19,7 @@ benchmarkingjob:
       - name: "tracking"
       #   # the url address of test algorithm configuration file; string type;
       #   # the file format supports yaml/yml;
-        url: "./examples/pedestrian_tracking/multiedge_inference_bench/testalgorithms/tracking/byte_track/byte_track_algorithm.yaml"
+        url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testalgorithms/tracking/byte_track/byte_track_algorithm.yaml"
 
   # the configuration of ranking leaderboard
   rank:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:

1. If this is your first time, please read our contributor guidelines: https://github.com/kubeedge/ianvs/blob/main/CONTRIBUTING.md
2. Ensure you have added or ran the appropriate tests for your PR

-->

**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR restores the MOT17 multi-object tracking benchmark by aligning baseline path specifications and data indexing schemas.

Specifically, it resolves:
- **Dataset Indexing**: Corrects `train_url` and `test_url` to `train_index` and `test_index` in `testenv.yaml` to properly match the evaluation engine's schema.
- **Path Mismatches**: Fixes broken `pedestrian_tracking` path references across `tracking_job.yaml`, `testenv.yaml`, and `byte_track_algorithm.yaml` by pointing them to the correct `MOT17/multiedge_inference_bench` root directory.
- **Workspace Portability**: Replaces the hardcoded absolute workspace path (`/ianvs/multiedge_inference_bench/workspace`) with a relative local path (`./ianvs-workspace/...`) in `tracking_job.yaml` to allow execution on bare-metal developer machines.

**Which issue(s) this PR fixes**:
Part of #495