### PR TITLE
fix: fix torch.hub.load warning and tensor/numpy bug in deit.py

### DIFF
--- a/examples/imagenet/multiedge_inference_bench/testalgorithms/automatic/models/transformers/deit.py
+++ b/examples/imagenet/multiedge_inference_bench/testalgorithms/automatic/models/transformers/deit.py
@@ -178,11 +178,14 @@ class DeiTModelShard(ModuleShard):
                              hub_model_name)
             else:
                 hub_model_name = model_name
-        model = torch.hub.load(hub_repo, hub_model_name, pretrained=True)
+        import warnings
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", FutureWarning)
+            model = torch.hub.load(hub_repo, hub_model_name, pretrained=True)
         state_dict = model.state_dict()
         weights = {}
         for key, val in state_dict.items():
-            weights[key] = val
+            weights[key] = val.detach().cpu().numpy()
         np.savez(model_file, **weights)
 
 


### PR DESCRIPTION
/kind bug

## What this PR does

Fixes two issues in `DeiTModelShard.save_weights()`:

1. Suppresses the `FutureWarning` raised by `torch.hub.load(..., pretrained=True)` in newer PyTorch versions.
2. Converts model weights to NumPy arrays before saving them with `np.savez()`.

## Why we need it

### Issue #486

`torch.hub.load(..., pretrained=True)` emits a `FutureWarning` in newer PyTorch versions, which can clutter logs and affect compatibility. The warning is now suppressed during model loading.

### Issue #485

The original implementation stored PyTorch tensors directly in the `weights` dictionary before calling `np.savez()`. This can lead to serialization issues because `np.savez()` is intended to store NumPy arrays.

Converting tensors using:

```python
val.detach().cpu().numpy()
```

ensures the weights are saved in a NumPy-compatible format.

## Changes

* Wrapped `torch.hub.load()` in a `warnings.catch_warnings()` block and suppressed `FutureWarning`.
* Converted tensors to NumPy arrays before storing them in the weights dictionary.
* Updated:
  `examples/imagenet/multiedge_inference_bench/testalgorithms/automatic/models/transformers/deit.py`

## Which issue(s) this PR fixes

Fixes #485

Fixes #486
