### PR TITLE
fix: add requirements.txt for smart_coding example

### DIFF
--- a/examples/smart_coding/requirements.txt
+++ b/examples/smart_coding/requirements.txt
@@ -8,6 +8,7 @@ tqdm>=4.60.0
 # LLM inference and model loading
 torch>=1.8.0
 transformers>=4.20.0
+accelerate>=0.20.0
 
 # OpenAI API client
 openai>=1.0.0

--- a/examples/smart_coding/requirements.txt
+++ b/examples/smart_coding/requirements.txt
@@ -1,0 +1,13 @@
+# Smart Coding Learning Bench Dependencies
+# LLM-based code generation benchmark for KubeEdge Ianvs
+
+# Core ML/AI packages
+numpy>=1.19.0
+tqdm>=4.60.0
+
+# LLM inference and model loading
+torch>=1.8.0
+transformers>=4.20.0
+
+# OpenAI API client
+openai>=1.0.0


### PR DESCRIPTION
## What does this PR do?
Adds a `requirements.txt` for the `smart_coding` example
as requested in issue #132.

## Related Issue
Fixes #132

## Changes Made
- Created `examples/smart_coding/requirements.txt`
- Listed all third-party dependencies:
  numpy, tqdm, torch, transformers, openai
- Excluded Python built-ins (os, re, time, logging etc.)
- Excluded internal ianvs packages (sedna, core)

## Why this matters
New contributors can now set up this example with:
`pip install -r examples/smart_coding/requirements.txt`