### PR TITLE
fix: add missing DDP/dist imports, fix assertion and YAML indentation in ByteTrack

### DIFF
--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testalgorithms/tracking/byte_track/basemodel.py
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testalgorithms/tracking/byte_track/basemodel.py
@@ -85,10 +85,11 @@ class BaseModel:
         self.args.experiment_name = self.exp.exp_name
 
         num_gpu = torch.cuda.device_count()
-        assert num_gpu >= 1, (
-            f"No CUDA-capable GPU detected (torch.cuda.device_count() = {num_gpu}). "
-            "The ByteTrack tracking job requires at least one CUDA GPU."
-        )
+        if num_gpu < 1:
+            raise RuntimeError(
+                f"No CUDA-capable GPU detected (torch.cuda.device_count() = {num_gpu}). "
+                "The ByteTrack tracking job requires at least one CUDA GPU."
+            )
         self.is_distributed = num_gpu > 1
         # set environment variables for distributed training
         cudnn.benchmark = True

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testalgorithms/tracking/byte_track/basemodel.py
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testalgorithms/tracking/byte_track/basemodel.py
@@ -20,6 +20,8 @@ from pathlib import Path
 
 import torch
 import torch.backends.cudnn as cudnn
+import torch.distributed as dist
+from torch.nn.parallel import DistributedDataParallel as DDP
 import motmetrics as mm
 from loguru import logger
 from sedna.common.class_factory import ClassType, ClassFactory
@@ -83,7 +85,10 @@ class BaseModel:
         self.args.experiment_name = self.exp.exp_name
 
         num_gpu = torch.cuda.device_count()
-        assert num_gpu <= torch.cuda.device_count()
+        assert num_gpu >= 1, (
+            f"No CUDA-capable GPU detected (torch.cuda.device_count() = {num_gpu}). "
+            "The ByteTrack tracking job requires at least one CUDA GPU."
+        )
         self.is_distributed = num_gpu > 1
         # set environment variables for distributed training
         cudnn.benchmark = True

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testalgorithms/tracking/byte_track/byte_track_algorithm.yaml
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testalgorithms/tracking/byte_track/byte_track_algorithm.yaml
@@ -17,11 +17,10 @@ algorithm:
       # example: basemodel.py has BaseModel module that the alias is "FPN" for this benchmarking;
       name: "ByteTrack"
       # the url address of python module; string type;
-      url: "./examples/pedestrian_tracking/multiedge_inference_bench/testalgorithms/tracking/byte_track/basemodel.py"
+      url: "./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testalgorithms/tracking/byte_track/basemodel.py"
 
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
-        # name of the hyperparameter; string type;
-          - batch_size:
-             values:
+        - batch_size:
+            values:
               - 1


### PR DESCRIPTION
## What this PR does
Fixes three bugs in the ByteTrack tracking algorithm files,
addressing issues #443 and #444.

## Fix 1 — Missing DDP and dist imports (#443)
`torch.nn.parallel.DistributedDataParallel` (DDP) and 
`torch.distributed` (dist) were used in `load()` and 
`_get_eval_loader()` respectively but never imported.

Both NameErrors are completely silent on single-GPU and 
CPU machines since the distributed code paths are gated 
behind `self.is_distributed = num_gpu > 1`. On any 
multi-GPU machine — precisely the environment the 
multiedgeinference paradigm is designed for — both 
cause immediate NameError crashes.

Added:
  import torch.distributed as dist
  from torch.nn.parallel import DistributedDataParallel as DDP

## Fix 2 — Tautological assertion replaced (#444)
The original assertion:
  num_gpu = torch.cuda.device_count()
  assert num_gpu <= torch.cuda.device_count()

always passes since num_gpu was assigned from the same 
call. On CPU-only machines num_gpu=0 and the assertion 
still passes, deferring failure to a cryptic 
RuntimeError deep in the stack.

Replaced with a meaningful guard:
  assert num_gpu >= 1, "No CUDA-capable GPU detected..."

Gives CPU-only users a clear early diagnostic instead 
of a confusing late-stage RuntimeError.

## Fix 3 — YAML indentation and stale path (#444)
byte_track_algorithm.yaml had two issues:

1. batch_size indented with 10 spaces instead of 8,
   causing ScannerError or silent drop of the 
   hyperparameter depending on PyYAML version.
   Fixed to match the correct format used in the
   sibling m3l_algorithm.yaml.

2. Stale url pointing to:
   ./examples/pedestrian_tracking/multiedge_inference_bench/...
   Corrected to:
   ./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/...

## Testing
Verified on macOS, Python 3.14, PyYAML 6.0.3:
- dist import present ✅
- DDP import present ✅
- tautological assert removed ✅
- meaningful assert num_gpu >= 1 added ✅
- YAML parses correctly, batch_size=1 accessible ✅
- url path contains MOT17 ✅

Note: Full multi-GPU execution not testable on Mac.
Fixes are import-level and config-level with no 
logic modification to inference paths.

Fixes #443
Fixes #444