### PR TITLE
fix(examples): add missing BaseDataSource import in sedna_predict.py

### DIFF
--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/sedna_predict.py
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/sedna_predict.py
@@ -15,7 +15,7 @@ from torchvision.transforms import ToPILImage
 from torchvision import transforms
 from torch.utils.data import DataLoader
 
-from sedna.datasources import IndexDataParse
+from sedna.datasources import IndexDataParse, BaseDataSource
 from sedna.core.lifelong_learning import LifelongLearning
 from sedna.common.config import Context
 


### PR DESCRIPTION
## What this PR does
Fixes #466

## Problem
`sedna_predict.py` uses `BaseDataSource` at line 46 inside 
`pre_data_process()`, but `BaseDataSource` was never imported.

The existing import only brought in `IndexDataParse`:
```python
from sedna.datasources import IndexDataParse
```
This caused a `NameError: name 'BaseDataSource' is not defined`
whenever `pre_data_process()` was called, making the prediction 
script completely unusable.

## Root Cause
The file was copied/adapted from another script and the 
`BaseDataSource` import was not carried over. Every other file 
in this example imports it correctly — for example 
`task_definition_by_domain.py`:
```python
from sedna.datasources import BaseDataSource
```

## Fix
Added `BaseDataSource` to the existing `sedna.datasources` import:
```python
from sedna.datasources import IndexDataParse, BaseDataSource
```

## Files Changed
- `examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/sedna_predict.py`