### PR TITLE
fix: update stale 2-domain config to 3-domain in robot-cityscapes-synthia

### DIFF
--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/sedna_evaluate.py
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/sedna_evaluate.py
@@ -20,9 +20,9 @@ def eval():
     eval_data.parse(eval_dataset_url, use_raw=False)
 
     task_allocation = {
-        "method": "TaskAllocationByOrigin",
+        "method": "TaskAllocationByDomain",
         "param": {
-            "origins": ["real", "sim"]
+            "origins": ["Cityscapes", "Synthia", "Cloud-Robotics"]
         }
     }
 

--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/sedna_train.py
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/sedna_train.py
@@ -20,16 +20,16 @@ def _load_txt_dataset(dataset_url):
 
 def train(estimator, train_data):
     task_definition = {
-        "method": "TaskDefinitionByOrigin",
+        "method": "TaskDefinitionByDomain",
         "param": {
-            "origins": ["real", "sim"]
+            "origins": ["Cityscapes", "Synthia", "Cloud-Robotics"]
         }
     }
 
     task_allocation = {
-        "method": "TaskAllocationByOrigin",
+        "method": "TaskAllocationByDomain",
         "param": {
-            "origins": ["real", "sim"]
+            "origins": ["Cityscapes", "Synthia", "Cloud-Robotics"]
         }
     }
 

--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/test_algorithm.yaml
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/test_algorithm.yaml
@@ -25,7 +25,7 @@ algorithm:
       # example: basemodel.py has BaseModel module that the alias is "FPN" for this benchmarking;
       name: "BaseModel"
       # the url address of python module; string type;
-      url: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testalgorithms/erfnet/basemodel.py"
+      url: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/basemodel.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -40,7 +40,7 @@ algorithm:
       # name of python module; string type;
       name: "TaskDefinitionByDomain"
       # the url address of python module; string type;
-      url: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testalgorithms/erfnet/task_definition_by_domain.py"
+      url: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/task_definition_by_domain.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -53,7 +53,7 @@ algorithm:
       # name of python module; string type;
       name: "TaskAllocationByDomain"
       # the url address of python module; string type;
-      url: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testalgorithms/erfnet/task_allocation_by_domain.py"
+      url: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/task_allocation_by_domain.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;

--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/test_algorithm.yaml
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/test_algorithm.yaml
@@ -25,7 +25,7 @@ algorithm:
       # example: basemodel.py has BaseModel module that the alias is "FPN" for this benchmarking;
       name: "BaseModel"
       # the url address of python module; string type;
-      url: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/basemodel.py"
+      url: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/basemodel.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;


### PR DESCRIPTION
## What this PR does
Fixes stale 2-domain configuration in robot-cityscapes-synthia
standalone scripts to match the 3-domain Ianvs benchmark YAML.

## Root Cause
sedna_evaluate.py and sedna_train.py were copied from
examples/robot/lifelong_learning_bench and never updated
after PR #85 introduced the MDIL-SS 3-domain configuration.

## Changes

### sedna_evaluate.py
- TaskAllocationByOrigin → TaskAllocationByDomain
- origins: ["real", "sim"] → ["Cityscapes", "Synthia", "Cloud-Robotics"]

### sedna_train.py
- TaskDefinitionByOrigin → TaskDefinitionByDomain
- TaskAllocationByOrigin → TaskAllocationByDomain
- origins: ["real", "sim"] → ["Cityscapes", "Synthia", "Cloud-Robotics"]

### test_algorithm.yaml (bonus fix)
- Fixed stale module URLs pointing to
  class_increment_semantic_segmentation instead of
  robot-cityscapes-synthia

## Impact
Before this fix: running python sedna_evaluate.py used
TaskAllocationByOrigin with ["real", "sim"] — silently
failing to match any Cityscapes/Synthia/Cloud-Robotics sample.
After: standalone scripts and Ianvs benchmark run use
identical task allocation logic.

## Testing
- TaskAllocationByDomain present in sedna_evaluate.py ✅
- TaskDefinitionByDomain + TaskAllocationByDomain in sedna_train.py ✅
- Stale TaskAllocationByOrigin/TaskDefinitionByOrigin removed ✅
- Correct origins ["Cityscapes", "Synthia", "Cloud-Robotics"] ✅

Fixes #463