### PR TITLE
fix(examples): add missing BaseDataSource import in RFNet sedna_predict.py files

### DIFF
--- a/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/RFNet/sedna_predict.py
+++ b/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/RFNet/sedna_predict.py
@@ -18,7 +18,7 @@ from torchvision.transforms import ToPILImage
 from torchvision import transforms
 from torch.utils.data import DataLoader
 
-from sedna.datasources import IndexDataParse
+from sedna.datasources import IndexDataParse, BaseDataSource
 from sedna.core.lifelong_learning import LifelongLearning
 from sedna.common.config import Context
 

--- a/examples/cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/RFNet/sedna_predict.py
+++ b/examples/cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/RFNet/sedna_predict.py
@@ -18,7 +18,7 @@ from torchvision.transforms import ToPILImage
 from torchvision import transforms
 from torch.utils.data import DataLoader
 
-from sedna.datasources import IndexDataParse
+from sedna.datasources import IndexDataParse, BaseDataSource
 from sedna.core.lifelong_learning import LifelongLearning
 from sedna.common.config import Context
 

--- a/examples/cityscapes-synthia/scene-based-unknown-task-recognition/curb-detection/testalgorithms/rfnet/RFNet/sedna_predict.py
+++ b/examples/cityscapes-synthia/scene-based-unknown-task-recognition/curb-detection/testalgorithms/rfnet/RFNet/sedna_predict.py
@@ -18,7 +18,7 @@ from torchvision.transforms import ToPILImage
 from torchvision import transforms
 from torch.utils.data import DataLoader
 
-from sedna.datasources import IndexDataParse
+from sedna.datasources import IndexDataParse, BaseDataSource
 from sedna.core.lifelong_learning import LifelongLearning
 from sedna.common.config import Context
 

--- a/examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/RFNet/sedna_predict.py
+++ b/examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/RFNet/sedna_predict.py
@@ -18,7 +18,7 @@ from torchvision.transforms import ToPILImage
 from torchvision import transforms
 from torch.utils.data import DataLoader
 
-from sedna.datasources import IndexDataParse
+from sedna.datasources import IndexDataParse, BaseDataSource
 from sedna.core.lifelong_learning import LifelongLearning
 from sedna.common.config import Context
 


### PR DESCRIPTION
## Summary

Fixes #522

Adds the missing `BaseDataSource` import across 4 RFNet `sedna_predict.py` files, following the same fix applied in #512 for the ERFNet path.

## Problem

`BaseDataSource` is used in `pre_data_process()` in all 4 files:

```python
data = BaseDataSource(data_type="test")
```

But only `IndexDataParse` was imported:

```python
from sedna.datasources import IndexDataParse
```

If this code path is executed and `BaseDataSource` is not provided by the runtime environment, Python is expected to raise:

`NameError: name 'BaseDataSource' is not defined`

## Fix

```python
# Before
from sedna.datasources import IndexDataParse

# After
from sedna.datasources import IndexDataParse, BaseDataSource
```

## Files Changed

* `examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/RFNet/sedna_predict.py`
* `examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/RFNet/sedna_predict.py`
* `examples/cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/RFNet/sedna_predict.py`
* `examples/cityscapes-synthia/scene-based-unknown-task-recognition/curb-detection/testalgorithms/rfnet/RFNet/sedna_predict.py`

## Validation

* [x] Verified `BaseDataSource` is used but missing from imports in all 4 files
* [x] Change is minimal ,only the missing import is added
* [x] DCO signed off

## Related

* Same fix applied to ERFNet path: #466 (PR #512)
