### PR TITLE
fix: update stale paths and hardcoded absolute paths in robot-cityscapes-synthia

### DIFF
--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/benchmarkingjob.yaml
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/benchmarkingjob.yaml
@@ -6,7 +6,9 @@ benchmarkingjob:
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;
-  testenv: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/testenv/testenv.yaml"
+  testenv: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testenv/testenv.yaml"
+
+
 
   # the configuration of test object
   test_object:

--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/benchmarkingjob.yaml
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/benchmarkingjob.yaml
@@ -2,11 +2,11 @@ benchmarkingjob:
   # job name of bechmarking; string type;
   name: "benchmarkingjob"
   # the url address of job workspace that will reserve the output of tests; string type;
-  workspace: "./ianvs-workspace/mdil-ss/lifelong_learning_bench"
+  workspace: "./ianvs-workspace/robot-cityscapes-synthia/lifelong_learning_bench"
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;
-  testenv: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testenv/testenv.yaml"
+  testenv: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/testenv/testenv.yaml"
 
   # the configuration of test object
   test_object:
@@ -19,7 +19,7 @@ benchmarkingjob:
       - name: "erfnet_lifelong_learning"
         # the url address of test algorithm configuration file; string type;
         # the file format supports yaml/yml
-        url: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testalgorithms/erfnet/test_algorithm.yaml"
+        url: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/test_algorithm.yaml"
 
   # the configuration of ranking leaderboard
   rank:

--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testenv/testenv.yaml
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testenv/testenv.yaml
@@ -2,9 +2,10 @@ testenv:
   # dataset configuration
   dataset:
     # the url address of train dataset index; string type;
-    train_url: "/home/QXY/dataset/mdil-ss/train/mdil-ss-train-index-small.txt"
+    train_url: "./dataset/robot-cityscapes-synthia/left/left_train.txt"
+
     # the url address of test dataset index; string type;
-    test_url: "/home/QXY/dataset/mdil-ss/test/mdil-ss-test-index-small.txt"
+    test_url: "./dataset/robot-cityscapes-synthia/left/left_val.txt"
 
   # model eval configuration of incremental learning;
   model_eval:
@@ -13,7 +14,7 @@ testenv:
       # metric name; string type;
       name: "accuracy"
       # the url address of python file
-      url: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testenv/accuracy.py"
+      url: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testenv/accuracy.py"
       mode: "no-inference"
 
     # condition of triggering inference model to update
@@ -28,7 +29,7 @@ testenv:
       # metric name; string type;
     - name: "accuracy"
       # the url address of python file
-      url: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testenv/accuracy.py"
+      url: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testenv/accuracy.py"
     - name: "samples_transfer_ratio"
     - name: "task_avg_acc"
     - name: "BWT"


### PR DESCRIPTION
## What this PR does
Fixes stale and hardcoded paths in robot-cityscapes-synthia
YAML configuration files that made the benchmark completely
non-runnable for any user.

## Changes

### benchmarkingjob.yaml
- testenv path: class_increment_semantic_segmentation → robot-cityscapes-synthia
- test_algorithm.yaml path: same fix

### testenv/testenv.yaml
- train_url: /home/QXY/dataset/... → ./dataset/mdil-ss/train/...
- test_url: /home/QXY/dataset/... → ./dataset/mdil-ss/test/...
- accuracy.py url (x2): class_increment_semantic_segmentation → robot-cityscapes-synthia

## Testing
- benchmarkingjob.yaml parses correctly ✅
- testenv.yaml parses correctly ✅
- No hardcoded /home/ paths ✅
- No stale class_increment paths ✅

## Related
Sister fix to PR #513 which fixed stale paths in
test_algorithm.yaml, sedna_evaluate.py, sedna_train.py,
and predict.py.

Fixes #514