### PR TITLE
fix: make query-routing example importable on non-CUDA platforms

### DIFF
--- a/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/edge_model.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/edge_model.py
@@ -18,7 +18,7 @@ import os
 
 from core.common.log import LOGGER
 from sedna.common.class_factory import ClassType, ClassFactory
-from models import HuggingfaceLLM, APIBasedLLM, VllmLLM, EagleSpecDecModel, LadeSpecDecLLM
+from models import HuggingfaceLLM, APIBasedLLM, VllmLLM, EagleSpecDecModel
 
 os.environ['BACKEND_TYPE'] = 'TORCH'
 
@@ -44,9 +44,10 @@ class EdgeModel:
         self.kwargs = kwargs
         self.model_name = kwargs.get("model", None)
         self.backend = kwargs.get("backend", "huggingface")
-        if self.backend not in ["huggingface", "vllm", "api"]:
+        if self.backend not in ["huggingface", "vllm", "api", "EagleSpecDec"]:
             raise ValueError(
-                f"Unsupported backend: {self.backend}. Supported options are: 'huggingface', 'vllm', 'api'."
+                f"Unsupported backend: {self.backend}. Supported options are: "
+                "'huggingface', 'vllm', 'api', 'EagleSpecDec'."
             )
         self._set_config()
 
@@ -68,13 +69,18 @@ class EdgeModel:
             if self.backend == "huggingface":
                 self.model = HuggingfaceLLM(**self.kwargs)
             elif self.backend == "vllm":
+                if VllmLLM is None:
+                    raise ImportError(
+                        "backend 'vllm' requires the vllm package, which is only "
+                        "available on Linux with CUDA. Use 'huggingface' or 'api' instead."
+                    )
                 self.model = VllmLLM(**self.kwargs)
             elif self.backend == "api":
                 self.model = APIBasedLLM(**self.kwargs)
             elif self.backend == "EagleSpecDec":
                 self.model = EagleSpecDecModel(**self.kwargs)
-            elif self.backend == "LadeSpecDec":
-                self.model = LadeSpecDecLLM(**self.kwargs)
+        except ImportError:
+            raise
         except Exception as e:
             LOGGER.error(f"Failed to initialize model backend `{self.backend}`: {str(e)}")
             raise RuntimeError(f"Model loading failed for backend `{self.backend}`.") from e

--- a/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/__init__.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/__init__.py
@@ -1,5 +1,10 @@
 from .api_llm import APIBasedLLM
 from .huggingface_llm import HuggingfaceLLM
-from .vllm_llm import VllmLLM
+# vllm is only installable on Linux with CUDA; keep it optional so the
+# 'huggingface' and 'api' backends remain usable on other platforms.
+try:
+    from .vllm_llm import VllmLLM
+except ImportError:
+    VllmLLM = None
 from .base_llm import BaseLLM
 from .eagle_llm import EagleSpecDecModel


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
The models package in the cloud-edge collaborative inference example currently imports VllmLLM unconditionally. Since vllm is only installable on Linux with CUDA, this prevents the example from loading on macOS/CPU environments even when the user has configured the 'huggingface' or 'api' backend, which work fine on those platforms.

This change:
- Makes the VllmLLM import optional in models/__init__.py, so the package loads wherever its other backends are supported.
- Raises a clear, actionable ImportError from EdgeModel.load() when the 'vllm' backend is requested but vllm is not installed, rather than failing with a confusing NoneType error.
- Removes the LadeSpecDecLLM import and its dispatch branch, as the implementation file is not yet part of the repository and the import causes an ImportError on all platforms. This can easily be restored alongside the implementation when that work lands.

No behavior changes for Linux/CUDA users with vllm installed.

Tested by importing the models package on macOS without vllm and confirming the 'huggingface'/'api' paths resolve correctly.

**Which issue(s) this PR fixes**:
Fixes # N/A