### PR TITLE
fix(metrics): correct compute() return values to prevent ValueError crash

### DIFF
--- a/core/testcasecontroller/metrics/metrics.py
+++ b/core/testcasecontroller/metrics/metrics.py
@@ -65,9 +65,7 @@ def compute(key, matrix):
             break
 
     if not flag:
-        bwt_score = np.nan
-        fwt_score = np.nan
-        return bwt_score, fwt_score
+        return None, np.nan, np.nan
 
     for i in range(length - 1):
         for j in range(length - 1):

--- a/core/testcasecontroller/metrics/metrics.py
+++ b/core/testcasecontroller/metrics/metrics.py
@@ -57,12 +57,16 @@ def compute(key, matrix):
     accuracy = 0.0
     bwt_score = 0.0
     fwt_score = 0.0
-    flag = True
 
-    for row in matrix:
-        if not isinstance(row, list) or len(row) != length - 1:
-            flag = False
-            break
+    # A matrix with fewer than two rows leaves no task pair to compare, and the
+    # score normalisation below would divide by (length - 1) == 0.
+    flag = length > 1
+
+    if flag:
+        for row in matrix:
+            if not isinstance(row, list) or len(row) != length - 1:
+                flag = False
+                break
 
     if not flag:
         return None, np.nan, np.nan


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR fixes a bug in `core/testcasecontroller/metrics/metrics.py` that causes a `ValueError: not enough values to unpack (expected 3, got 2)` when running lifelong learning or incremental learning benchmarks with a malformed (non-square) task matrix.

Previously, when the `compute()` function detected a malformed matrix (`flag=False`), it returned a 2-tuple: `(bwt_score, fwt_score)`. However, all callers of this function (e.g. `bwt_func`, `fwt_func`, `matrix_func`) unconditionally expect a 3-tuple (`_, BWT_score, _ = compute(...)`), resulting in an immediate crash. 

This commit updates the error path of `compute()` to consistently return a 3-tuple `(None, np.nan, np.nan)` when `flag=False`, satisfying caller expectations. 

**Which issue(s) this PR fixes**:
Fixes #531

**Special notes for your reviewer**:
N/A
