### PR TITLE
fix(examples): add missing BaseDataSource import to RFNet sedna_predict.py files

### DIFF
--- a/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/RFNet/sedna_predict.py
+++ b/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/RFNet/sedna_predict.py
@@ -18,7 +18,7 @@ from torchvision.transforms import ToPILImage
 from torchvision import transforms
 from torch.utils.data import DataLoader
 
-from sedna.datasources import IndexDataParse
+from sedna.datasources import IndexDataParse, BaseDataSource
 from sedna.core.lifelong_learning import LifelongLearning
 from sedna.common.config import Context
 

--- a/examples/cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/RFNet/sedna_predict.py
+++ b/examples/cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/RFNet/sedna_predict.py
@@ -18,7 +18,7 @@ from torchvision.transforms import ToPILImage
 from torchvision import transforms
 from torch.utils.data import DataLoader
 
-from sedna.datasources import IndexDataParse
+from sedna.datasources import IndexDataParse, BaseDataSource
 from sedna.core.lifelong_learning import LifelongLearning
 from sedna.common.config import Context
 

--- a/examples/cityscapes-synthia/scene-based-unknown-task-recognition/curb-detection/testalgorithms/rfnet/RFNet/sedna_predict.py
+++ b/examples/cityscapes-synthia/scene-based-unknown-task-recognition/curb-detection/testalgorithms/rfnet/RFNet/sedna_predict.py
@@ -18,7 +18,7 @@ from torchvision.transforms import ToPILImage
 from torchvision import transforms
 from torch.utils.data import DataLoader
 
-from sedna.datasources import IndexDataParse
+from sedna.datasources import IndexDataParse, BaseDataSource
 from sedna.core.lifelong_learning import LifelongLearning
 from sedna.common.config import Context
 

--- a/examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/RFNet/sedna_predict.py
+++ b/examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/RFNet/sedna_predict.py
@@ -18,7 +18,7 @@ from torchvision.transforms import ToPILImage
 from torchvision import transforms
 from torch.utils.data import DataLoader
 
-from sedna.datasources import IndexDataParse
+from sedna.datasources import IndexDataParse, BaseDataSource
 from sedna.core.lifelong_learning import LifelongLearning
 from sedna.common.config import Context
 


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
This PR adds the missing `BaseDataSource` import to the four RFNet `sedna_predict.py` files.

Previously, these files instantiated `BaseDataSource(data_type="test")` in the `pre_data_process()` method but only imported `IndexDataParse` from `sedna.datasources`. If this execution path is hit without the import, it results in a `NameError: name 'BaseDataSource' is not defined`.

This commit adds `BaseDataSource` to the existing `sedna.datasources` import statement across the 4 affected files:

* `examples/robot/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/RFNet/sedna_predict.py`
* `examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/testalgorithms/rfnet/RFNet/sedna_predict.py`
* `examples/cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/rfnet/RFNet/sedna_predict.py`
* `examples/cityscapes-synthia/scene-based-unknown-task-recognition/curb-detection/testalgorithms/rfnet/RFNet/sedna_predict.py`

**Which issue(s) this PR fixes**:
Fixes #522

**Special notes for your reviewer**:
- This supersedes #525 (byte-identical change on the same four files) so the same edit isn't merged twice.
- An earlier revision of this PR also touched the ERFNet file under `examples/robot-cityscapes-synthia/`; that path was already fixed on main by #512, and after rebasing onto current main that hunk dropped — this PR now covers exactly the four files still affected.
- Verification (pyflakes over all five vendored RFNet/ERFNet trees): pre-fix files report `undefined name 'BaseDataSource'`; post-fix files report no undefined names. No other runtime-relevant undefined symbols found in the ianvs-loaded entry points.
