### PR TITLE
fix: resolve execution blockers and hardcoded paths in llm_simple_qa benchmark

### DIFF
--- a/examples/llm_simple_qa/README.md
+++ b/examples/llm_simple_qa/README.md
@@ -4,7 +4,13 @@
 
 ### Prepare Data
 
-The data of simple-qa example structure is:
+Generate the dataset by running the provided script from the repository root:
+
+```shell
+python examples/llm_simple_qa/prepare_data.py
+```
+
+This writes the following structure under `examples/llm_simple_qa/dataset/`:
 
 ```
 .
@@ -14,7 +20,8 @@ The data of simple-qa example structure is:
     └── data.jsonl
 ```
 
-`train_data/data.jsonl` is empty, and the `test_data/data.jsonl` is as follows:
+`train_data/data.jsonl` is empty, and the `test_data/data.jsonl` contains one
+JSON object per line (JSONL format). Its contents are as follows:
 
 ```
 {
@@ -63,14 +70,14 @@ The data of simple-qa example structure is:
 
 You need to install the changed-sedna package, which added `JsonlDataParse` in `sedna.datasources`
 
-Replace the file in `yourpath/anaconda3/envs/ianvs/lib/python3.x/site-packages/sedna` with `examples/resources/sedna-with-jsonl.zip`
+Replace the file in `yourpath/anaconda3/envs/ianvs/lib/python3.x/site-packages/sedna` with `examples/resources/sedna-llm.zip`
 
 
 ### Run Ianvs
 
 Run the following command:
 
-`ianvs -f examples/llm/singletask_learning_bench/simple_qa/benchmarkingjob.yaml`
+`ianvs -f examples/llm_simple_qa/benchmarkingjob.yaml`
 
 ## OpenCompass Evaluation
 
@@ -80,5 +87,5 @@ Run the following command:
 
 ### Run Evaluation
 
-`python run_op.py examples/llm/singletask_learning_bench/simple_qa/testalgorithms/gen/op_eval.py`
+`python run_op.py examples/llm_simple_qa/testalgorithms/gen/op_eval.py`
 

--- a/examples/llm_simple_qa/benchmarkingjob.yaml
+++ b/examples/llm_simple_qa/benchmarkingjob.yaml
@@ -2,11 +2,11 @@ benchmarkingjob:
   # job name of bechmarking; string type;
   name: "benchmarkingjob"
   # the url address of job workspace that will reserve the output of tests; string type;
-  workspace: "/home/icyfeather/project/ianvs/workspace"
+  workspace: "./examples/llm_simple_qa/workspace"
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;
-  testenv: "./examples/llm/singletask_learning_bench/simple_qa/testenv/testenv.yaml"
+  testenv: "./examples/llm_simple_qa/testenv/testenv.yaml"
 
   # the configuration of test object
   test_object:
@@ -19,7 +19,7 @@ benchmarkingjob:
       - name: "simple_qa_singletask_learning"
         # the url address of test algorithm configuration file; string type;
         # the file format supports yaml/yml;
-        url: "./examples/llm/singletask_learning_bench/simple_qa/testalgorithms/gen/gen_algorithm.yaml"
+        url: "./examples/llm_simple_qa/testalgorithms/gen/gen_algorithm.yaml"
 
   # the configuration of ranking leaderboard
   rank:

--- a/examples/llm_simple_qa/prepare_data.py
+++ b/examples/llm_simple_qa/prepare_data.py
@@ -1,0 +1,128 @@
+# Copyright 2022 The KubeEdge Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Generate the simple-qa dataset used by the llm_simple_qa benchmark.
+
+The Sedna ``JsonlDataParse`` parser expects exactly one valid JSON object per
+line. This script writes the dataset in that format so users do not have to
+hand-format the pretty-printed objects shown in the README.
+
+It creates the following layout, relative to this file::
+
+    examples/llm_simple_qa/dataset/
+    ├── test_data
+    │   └── data.jsonl
+    └── train_data
+        └── data.jsonl
+
+``train_data/data.jsonl`` is intentionally left empty because this example
+performs single-task evaluation only.
+
+Run from anywhere::
+
+    python examples/llm_simple_qa/prepare_data.py
+"""
+
+import json
+import os
+
+# Each item is written as a single line (one JSON object per line) so that the
+# JSONL parser can read it without choking on multi-line, pretty-printed JSON.
+TEST_DATA = [
+    {
+        "question": "If Xiao Ming has 5 apples, and he gives 3 to Xiao Hua, "
+                    "how many apples does Xiao Ming have left?\n"
+                    "A. 2\nB. 3\nC. 4\nD. 5",
+        "answer": "A",
+    },
+    {
+        "question": "Which of the following numbers is the smallest prime "
+                    "number?\nA. 0\nB. 1\nC. 2\nD. 4",
+        "answer": "C",
+    },
+    {
+        "question": "A rectangle has a length of 10 centimeters and a width of "
+                    "5 centimeters, what is its perimeter in centimeters?\n"
+                    "A. 20 centimeters\nB. 30 centimeters\n"
+                    "C. 40 centimeters\nD. 50 centimeters",
+        "answer": "B",
+    },
+    {
+        "question": "Which of the following fractions is closest to 1?\n"
+                    "A. 1/2\nB. 3/4\nC. 4/5\nD. 5/6",
+        "answer": "D",
+    },
+    {
+        "question": "If a number plus 10 equals 30, what is the number?\n"
+                    "A. 20\nB. 21\nC. 22\nD. 23",
+        "answer": "A",
+    },
+    {
+        "question": "Which of the following expressions has the largest "
+                    "result?\nA. 3 + 4\nB. 5 - 2\nC. 6 * 2\nD. 7 ÷ 2",
+        "answer": "C",
+    },
+    {
+        "question": "A class has 24 students, and if each student brings 2 "
+                    "books, how many books are there in total?\n"
+                    "A. 48\nB. 36\nC. 24\nD. 12",
+        "answer": "A",
+    },
+    {
+        "question": "Which of the following is the correct multiplication "
+                    "rhyme?\nA. Three threes are seven\n"
+                    "B. Four fours are sixteen\nC. Five fives are twenty-five\n"
+                    "D. Six sixes are thirty-six",
+        "answer": "B",
+    },
+    {
+        "question": "If one number is three times another number, and this "
+                    "number is 15, what is the other number?\n"
+                    "A. 5\nB. 10\nC. 15\nD. 45",
+        "answer": "A",
+    },
+    {
+        "question": "Which of the following shapes has the longest perimeter?\n"
+                    "A. Square\nB. Rectangle\nC. Circle\nD. Triangle",
+        "answer": "C",
+    },
+]
+
+
+def write_jsonl(path, records):
+    """Write ``records`` to ``path`` as JSONL (one JSON object per line)."""
+    dirname = os.path.dirname(path)
+    if dirname:
+        os.makedirs(dirname, exist_ok=True)
+    with open(path, "w", encoding="utf-8") as f:
+        for record in records:
+            f.write(json.dumps(record, ensure_ascii=False) + "\n")
+
+
+def main():
+    base_dir = os.path.join(os.path.dirname(os.path.abspath(__file__)),
+                            "dataset")
+    train_path = os.path.join(base_dir, "train_data", "data.jsonl")
+    test_path = os.path.join(base_dir, "test_data", "data.jsonl")
+
+    # train_data is empty for this single-task evaluation example.
+    write_jsonl(train_path, [])
+    write_jsonl(test_path, TEST_DATA)
+
+    print(f"Wrote {len(TEST_DATA)} records to {test_path}")
+    print(f"Wrote empty train set to {train_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/llm_simple_qa/testalgorithms/gen/basemodel.py
+++ b/examples/llm_simple_qa/testalgorithms/gen/basemodel.py
@@ -21,12 +21,17 @@ import zipfile
 import logging
 
 import numpy as np
+import torch
 from sedna.common.config import Context
 from sedna.common.class_factory import ClassType, ClassFactory
 
 
 from transformers import AutoModelForCausalLM, AutoTokenizer
-device = "cuda" # the device to load the model onto
+
+# Select the device dynamically so the example runs on machines without an
+# Nvidia GPU instead of crashing: CUDA when available, then Apple Silicon
+# (MPS), and finally CPU.
+device = "cuda" if torch.cuda.is_available() else ("mps" if torch.backends.mps.is_available() else "cpu")
 
 
 logging.disable(logging.WARNING)
@@ -40,12 +45,19 @@ os.environ['BACKEND_TYPE'] = 'TORCH'
 class BaseModel:
 
     def __init__(self, **kwargs):
+        model_name = "Qwen/Qwen2-0.5B-Instruct"
+        torch_dtype = torch.float32 if device == "cpu" else "auto"
         self.model = AutoModelForCausalLM.from_pretrained(
-            "/home/icyfeather/models/Qwen2-0.5B-Instruct",
-            torch_dtype="auto",
-            device_map="auto"
-        )
-        self.tokenizer = AutoTokenizer.from_pretrained("/home/icyfeather/models/Qwen2-0.5B-Instruct")
+            model_name,
+            torch_dtype=torch_dtype
+        ).to(device)
+        self.tokenizer = AutoTokenizer.from_pretrained(model_name)
+
+    def preprocess(self, data, **kwargs):
+        # The singletasklearning paradigm calls preprocess before predict.
+        # No preprocessing is required for this example, so pass the data
+        # through unchanged.
+        return data
 
     def train(self, train_data, valid_data=None, **kwargs):
         print("BaseModel doesn't need to train")

--- a/examples/llm_simple_qa/testalgorithms/gen/gen_algorithm.yaml
+++ b/examples/llm_simple_qa/testalgorithms/gen/gen_algorithm.yaml
@@ -15,4 +15,4 @@ algorithm:
       # example: basemodel.py has BaseModel module that the alias is "FPN" for this benchmarking;
       name: "gen"
       # the url address of python module; string type;
-      url: "./examples/llm/singletask_learning_bench/simple_qa/testalgorithms/gen/basemodel.py"
+      url: "./examples/llm_simple_qa/testalgorithms/gen/basemodel.py"

--- a/examples/llm_simple_qa/testenv/testenv.yaml
+++ b/examples/llm_simple_qa/testenv/testenv.yaml
@@ -2,13 +2,13 @@ testenv:
   # dataset configuration
   dataset:
     # the url address of train dataset index; string type;
-    train_data: "/home/icyfeather/Projects/ianvs/dataset/llm_simple_qa/train_data/data.jsonl"
+    train_data: "./examples/llm_simple_qa/dataset/train_data/data.jsonl"
     # the url address of test dataset index; string type;
-    test_data: "/home/icyfeather/Projects/ianvs/dataset/llm_simple_qa/test_data/data.jsonl"
+    test_data: "./examples/llm_simple_qa/dataset/test_data/data.jsonl"
 
   # metrics configuration for test case's evaluation; list type;
   metrics:
       # metric name; string type;
     - name: "acc"
       # the url address of python file
-      url: "./examples/llm/singletask_learning_bench/simple_qa/testenv/acc.py"
+      url: "./examples/llm_simple_qa/testenv/acc.py"


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
The `llm_simple_qa` example previously contained multiple execution-blocking bugs, including hardcoded local environment paths, missing framework interfaces, and missing dataset automation. These issues prevented users from executing the benchmark out-of-the-box.

Changes implemented:
- **Path Remediation:** Replaced all hardcoded absolute paths (`/home/icyfeather/...`) and stale relative paths (`./examples/llm/...`) with accurate, portable root-relative paths in `benchmarkingjob.yaml`, `testenv.yaml`, and `gen_algorithm.yaml`.
- **Dataset Automation:** Added a `prepare_data.py` script to automatically generate the required JSONL data structure. 
- **Hardware Abstraction & Model Loading:** Replaced the local model path with the Hugging Face Hub ID (`"Qwen/Qwen2-0.5B-Instruct"`). Replaced hardcoded `cuda` allocation with dynamic hardware detection (`"cuda" if torch.cuda.is_available() else "cpu"`) to prevent immediate crashes on non-Nvidia/CPU-only machines.
- **Framework Integration:** Added the missing `preprocess` pass-through method to `basemodel.py` to satisfy the `singletasklearning` paradigm requirements.
- **Documentation:** Corrected the referenced Sedna zip file name (`sedna-llm.zip`) and updated the execution paths in `README.md`.

**Which issue(s) this PR fixes:**
Fixes #368