### PR TITLE
fix(aoa/TForest) : add requirements.txt and harden hardcoded paths in tools.py

### DIFF
--- a/examples/aoa/single_task_bench/TForest/requirements.txt
+++ b/examples/aoa/single_task_bench/TForest/requirements.txt
@@ -1,0 +1,9 @@
+numpy>=1.21.0
+joblib>=1.1.0
+matplotlib>=3.5.0
+statsmodels>=0.13.0
+scienceplots>=2.0.0
+scikit-learn>=1.0.0
+tqdm>=4.64.0
+pandas>=1.3.0
+

--- a/examples/aoa/single_task_bench/TForest/tools.py
+++ b/examples/aoa/single_task_bench/TForest/tools.py
@@ -1,17 +1,21 @@
 import os
 import numpy as np
 import pandas as pd
+from pathlib import Path
 from sklearn.model_selection import train_test_split
+
+# Base directory relative to this file
+BASE_DIR = Path(__file__).resolve().parent
 
 
 def data_io(data_index=1):
-    path = 'data/processed/'
+    data_dir = BASE_DIR / 'data' / 'processed'
     # names = [str(i) for i in range(64, 86)] #64~86
     # CHANNEL_NUM = 52
     names = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 29, 30, 31, 32, 33, 34, 35, 36, 37, 38, 39, 40, 41, 42]
-
-    all_data = np.loadtxt(os.path.join(path + str(names[data_index]) + '.txt'), delimiter=',')
-#     print(os.path.join(path + str(names[data_index]) + '.txt'))
+    file_path = data_dir / f'{names[data_index]}.txt'
+    all_data = np.loadtxt(file_path, delimiter=',')
+#     print(file_path)
 # #     all_data = all_data.sample(frac=1.0)
 #     print(all_data.shape)
     # snr = all_data[:, 6:10]
@@ -40,7 +44,13 @@ def data_io(data_index=1):
     return all_features, all_labels
 
 
-def load_test(test_file='seq/seq83_new.txt'):
+def load_test(test_file=None):
+    if test_file is None:
+        test_file = BASE_DIR / "seq" / "seq83_new.txt"
+    else:
+        test_file = Path(test_file)
+        if not test_file.is_absolute():
+            test_file = BASE_DIR / test_file
     CHANNEL_NUM = 52
     test_seq = np.array(pd.read_table(test_file, header = None, sep=','))
     snr = test_seq[:, 6:10]


### PR DESCRIPTION
## Summary

Fixes the dependency and path-handling issues reported in #323 for the TForest example.

## Changes

* Add `requirements.txt` containing the runtime dependencies required by the TForest example:

  * `numpy`
  * `joblib`
  * `matplotlib`
  * `statsmodels`
  * `scienceplots`
  * `scikit-learn`
  * `tqdm`
  * `pandas`
* Replace hardcoded relative paths in `tools.py` with `pathlib`-based paths resolved relative to the script location.

## Issue Reproduction

On a clean environment, running the TForest example fails immediately with:

```text
ModuleNotFoundError: No module named 'statsmodels'
```

In addition, `tools.py` relied on relative paths that depend on the current working directory, making execution fragile when launched from different locations.

## Validation

Installed dependencies using:

```bash
pip install -r examples/aoa/single_task_bench/TForest/requirements.txt
```

Verified imports:

```bash
python -c "import numpy, joblib, matplotlib, statsmodels, scienceplots, sklearn, tqdm, pandas; print('All imports OK')"
```

Output:

```text
All imports OK
```

After installing dependencies, execution proceeds beyond the original import failure and reaches the next stage of the workflow.

Fixes #323

