### PR TITLE
fix: add guards against ZeroDivisionError across cloud-edge LLM metrics and backends

### DIFF
--- a/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/api_llm.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/api_llm.py
@@ -133,10 +133,9 @@ class APIBasedLLM(BaseLLM):
 
             if internal_token_latency:
                 internal_token_latency = sum(internal_token_latency) / len(internal_token_latency)
-                throughput = 1 / internal_token_latency
             else:
-                internal_token_latency = 0
-                throughput = 0
+                internal_token_latency = 0.0
+            throughput = (1.0 / internal_token_latency) if internal_token_latency > 0 else 0.0
 
         except Exception as e:
             raise RuntimeError(f"Error during API inference: {e}")

--- a/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/eagle_llm.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/eagle_llm.py
@@ -104,8 +104,11 @@ class EagleSpecDecModel(BaseLLM):
         text = generated_text
         completion_tokens = output_ids.shape[1] - prompt_tokens
         
-        internal_token_latency = sum(internal_token_latency) / completion_tokens
-        
+        if completion_tokens > 0:
+            internal_token_latency = sum(internal_token_latency) / completion_tokens
+        else:
+            internal_token_latency = 0.0
+
         if internal_token_latency != 0:
             throughput = 1 / internal_token_latency
         else:

--- a/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/huggingface_llm.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/huggingface_llm.py
@@ -123,8 +123,11 @@ class HuggingfaceLLM(BaseLLM):
 
         text = generated_text.replace("<|im_end|>", "")
         prompt_tokens = len(model_inputs.input_ids[0])
-        internal_token_latency = sum(internal_token_latency) / len(internal_token_latency)
-        throughput = 1 / internal_token_latency
+        if internal_token_latency:
+            internal_token_latency = sum(internal_token_latency) / len(internal_token_latency)
+        else:
+            internal_token_latency = 0.0
+        throughput = (1.0 / internal_token_latency) if internal_token_latency > 0 else 0.0
 
         response = self._format_response(
             text,

--- a/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/vllm_llm.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/vllm_llm.py
@@ -118,9 +118,12 @@ class VllmLLM(BaseLLM):
         # Time to First Token (s)
         time_to_first_token = metrics.first_token_time - metrics.arrival_time
         # Internal Token Latency (s)
-        internal_token_latency = (metrics.finished_time - metrics.first_token_time) / completion_tokens
+        if completion_tokens > 0:
+            internal_token_latency = (metrics.finished_time - metrics.first_token_time) / completion_tokens
+        else:
+            internal_token_latency = 0.0
         # Completion Throughput (Token/s)
-        throughput = 1 / internal_token_latency
+        throughput = (1.0 / internal_token_latency) if internal_token_latency > 0 else 0.0
 
         response = self._format_response(
             text,

--- a/examples/cloud-edge-collaborative-inference-for-llm/testenv/accuracy.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testenv/accuracy.py
@@ -47,6 +47,9 @@ def acc(y_true, y_pred):
 
     infer_res = [JointInferenceResult.from_list(*pred) for pred in y_pred]
 
+    if not infer_res:
+        return 0.0
+
     y_pred = [get_last_letter(pred.result.completion) for pred in infer_res]
     y_true = [get_last_letter(y) for y in y_true]
 

--- a/examples/cloud-edge-collaborative-inference-for-llm/testenv/edge_ratio.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testenv/edge_ratio.py
@@ -34,6 +34,9 @@ def edge_ratio(_, y_pred):
 
     infer_res = [JointInferenceResult.from_list(*pred) for pred in y_pred]
 
+    if not infer_res:
+        return 0.0
+
     y_pred = [pred.is_hard_example for pred in infer_res]
 
     edge_ratio = 1 - sum(y_pred) / len(y_pred)

--- a/examples/cloud-edge-collaborative-inference-for-llm/testenv/internal_token_latency.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testenv/internal_token_latency.py
@@ -36,6 +36,9 @@ def internal_token_latency(_, y_pred):
 
     infer_res = [JointInferenceResult.from_list(*pred) for pred in y_pred]
 
+    if not infer_res:
+        return 0.0
+
     average_itl = sum([pred.result.internal_token_latency for pred in infer_res]) / len(infer_res)
 
     return round(average_itl,3)

--- a/examples/cloud-edge-collaborative-inference-for-llm/testenv/throughput.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testenv/throughput.py
@@ -34,8 +34,11 @@ def throughput(_, y_pred):
 
     infer_res = [JointInferenceResult.from_list(*pred) for pred in y_pred]
 
+    if not infer_res:
+        return 0.0
+
     average_itl = sum([pred.result.internal_token_latency for pred in infer_res]) / len(infer_res)
 
-    average_throughput = 1 / average_itl
+    average_throughput = (1 / average_itl) if average_itl > 0 else 0.0
 
     return round(average_throughput,2)

--- a/examples/cloud-edge-collaborative-inference-for-llm/testenv/time_to_first_token.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testenv/time_to_first_token.py
@@ -34,6 +34,9 @@ def time_to_first_token(_, y_pred):
 
     infer_res = [JointInferenceResult.from_list(*pred) for pred in y_pred]
 
+    if not infer_res:
+        return 0.0
+
     average_ttft = sum([pred.result.time_to_first_token for pred in infer_res]) / len(infer_res)
 
     return round(average_ttft, 3)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
The `cloud-edge-collaborative-inference-for-llm` benchmark previously crashed with a `ZeroDivisionError` when executed against an empty dataset or when a model generated $\le1$ token (e.g., immediate EOS). 

This PR implements comprehensive, zero-safe division guards across the 5 metric modules and 4 backend wrappers to ensure the framework returns `0.0` gracefully under these edge cases, preserving the execution of the broader benchmark suite.

Files patched:
**Metrics:**
- `testenv/accuracy.py`
- `testenv/throughput.py`
- `testenv/internal_token_latency.py`
- `testenv/time_to_first_token.py`
- `testenv/edge_ratio.py`

**Backends:**
- `models/huggingface_llm.py`
- `models/vllm_llm.py`
- `models/eagle_llm.py`
- `models/api_llm.py` *(Identified and patched proactively)*

**Which issue(s) this PR fixes:**
Fixes #337