### PR TITLE
fix: migrate legacy Sedna API calls to standard inference methods in lifelong learning

### DIFF
--- a/core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py
+++ b/core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py
@@ -155,7 +155,7 @@ class LifelongLearning(ParadigmBase):
             inference_dataset = self.dataset.load_data(self.dataset.test_url, "eval",
                                                    feature_process=_data_feature_process)
             kwargs = {}
-            test_res = job.my_inference(inference_dataset, **kwargs)
+            test_res, _, _ = job.inference(inference_dataset, **kwargs)
             del job
             for key in my_dict.keys():
                 LOGGER.info(f"{key} scores: {my_dict[key]}")
@@ -333,7 +333,7 @@ class LifelongLearning(ParadigmBase):
         for i, _ in enumerate(inference_dataset.x):
             data = BaseDataSource(data_type="test")
             data.x = inference_dataset.x[i:(i + 1)]
-            res, is_unseen_task, _ = job.inference_2(data, **kwargs)
+            res, is_unseen_task, _ = job.inference(data, **kwargs)
             inference_results.append(res)
             if is_unseen_task:
                 unseen_tasks.append(inference_dataset.x[i])


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
The lifelong learning paradigm controller previously called `job.my_inference()` and `job.inference_2()`, which are internal Sedna fork methods absent from the public Sedna 0.6.0.1 API. These raised `AttributeError`s that blocked test inference from executing.

- Replaced the deprecated `job.my_inference()` and `job.inference_2()` calls with the standard `job.inference()` method.
- Aligned the core Ianvs framework with the public Sedna `LifelongLearning` API contract.
- Unblocked the final test inference step for all lifelong learning examples running in `no-inference` and hard-example mining modes.

**Which issue(s) this PR fixes:**
Fixes #461