### PR TITLE
fix: remove hardcoded CUDA assumptions in ERFNet to support CPU-only execution

### DIFF
--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/train.py
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/train.py
@@ -105,7 +105,8 @@ class Trainer(object):
                     "=> no checkpoint found at '{}'" .format(args.resume))
             print(f"Training: load model from {args.resume}")
             checkpoint = torch.load(
-                args.resume, map_location=torch.device('cuda:0'))
+                args.resume,
+                map_location=torch.device(f'cuda:{args.gpu_ids}' if args.cuda else 'cpu'))
             args.start_epoch = checkpoint['epoch']
 
             self.model.load_state_dict(checkpoint['state_dict'], False)
@@ -260,7 +261,8 @@ class Trainer(object):
                 target, 255, self.nclass[self.current_domain] - 1)
 
             target = target.squeeze(0)
-            target = target.cuda(self.gpu_ids)
+            if self.args.cuda:
+                target = target.cuda(self.gpu_ids)
 
             outputs_prev_task = self.model(
                 image, max(self.current_domain-1, 0))

--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/utils/args.py
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/utils/args.py
@@ -1,3 +1,6 @@
+import torch
+
+
 class TrainArgs:
     def __init__(self, **kwargs):
         self.depth = False
@@ -22,7 +25,7 @@ class TrainArgs:
         self.lr_scheduler = 'cos'
         self.momentum = 0.9
         self.weight_decay = 2.5e-5
-        self.no_cuda = False
+        self.no_cuda = kwargs.get("no_cuda", not torch.cuda.is_available())
         self.gpu_ids = 0
 
         self.seed = 1
@@ -31,7 +34,7 @@ class TrainArgs:
         self.ft = True
         self.eval_interval = kwargs.get("eval_interval", 50)
         self.no_val = kwargs.get("no_val", True)
-        self.cuda = True
+        self.cuda = kwargs.get("cuda", not self.no_cuda and torch.cuda.is_available())
         self.savedir = './dataset/mdil-ss/save'
 
 class ValArgs:
@@ -48,7 +51,7 @@ class ValArgs:
         self.current_domain = 0
         self.next_domain = 1
 
-        self.no_cuda = False
+        self.no_cuda = kwargs.get("no_cuda", not torch.cuda.is_available())
         self.gpu_ids = 0
         self.checkname = None
         self.weight_path = "./models/530_exp3_2.pth"
@@ -58,4 +61,4 @@ class ValArgs:
         self.label_save_path = './test/label'
         self.merge = True
         self.depth = False
-        self.cuda = True
+        self.cuda = kwargs.get("cuda", not self.no_cuda and torch.cuda.is_available())


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
The ERFNet training and evaluation utilities contained hardcoded CUDA availability assumptions, causing the pipeline to crash immediately on CPU-only machines and Apple Silicon devices. 

- Dynamically assigned `self.cuda = torch.cuda.is_available()` (and `self.no_cuda`) within `TrainArgs` and `ValArgs` in `utils/args.py`.
- Refactored checkpoint loading in `train.py` to use a dynamic `map_location` supporting CPU fallback.
- Added a missing `if self.args.cuda:` guard around a `target.cuda()` call within the `training()` loop in `train.py` to match the surrounding tensor handling logic.

This unblocks ERFNet execution for contributors running the benchmark on non-NVIDIA hardware.

**Which issue(s) this PR fixes:**
Fixes #471