### PR TITLE
fix: update deprecated torchvision make_grid API and resolve DataLoader worker import failures

### DIFF
--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/utils/args.py
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/utils/args.py
@@ -2,7 +2,7 @@ class TrainArgs:
     def __init__(self, **kwargs):
         self.depth = False
         self.dataset = 'cityscapes'
-        self.workers = 4
+        self.workers = kwargs.get("workers", 0)
         self.base_size = 1024
         self.crop_size = 768
         self.loss_type = 'ce'

--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/utils/summaries.py
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/utils/summaries.py
@@ -19,10 +19,10 @@ class TensorboardSummary(object):
             writer.add_image('Image', grid_image, global_step)
 
             grid_image = make_grid(decode_seg_map_sequence(torch.max(output[:3], 1)[1].detach().cpu().numpy(),
-                                                           dataset=dataset), 3, normalize=False, range=(0, 255))
+                                                           dataset=dataset), 3, normalize=False, value_range=(0, 255))
             writer.add_image('Predicted label', grid_image, global_step)
             grid_image = make_grid(decode_seg_map_sequence(torch.squeeze(target[:3], 1).detach().cpu().numpy(),
-                                                           dataset=dataset), 3, normalize=False, range=(0, 255))
+                                                           dataset=dataset), 3, normalize=False, value_range=(0, 255))
             writer.add_image('Groundtruth label', grid_image, global_step)
         else:
             grid_image = make_grid(image[:3].clone().cpu().data, 4, normalize=True)
@@ -32,8 +32,8 @@ class TensorboardSummary(object):
             writer.add_image('Depth', grid_image, global_step)
 
             grid_image = make_grid(decode_seg_map_sequence(torch.max(output[:3], 1)[1].detach().cpu().numpy(),
-                                                           dataset=dataset), 4, normalize=False, range=(0, 255))
+                                                           dataset=dataset), 4, normalize=False, value_range=(0, 255))
             writer.add_image('Predicted label', grid_image, global_step)
             grid_image = make_grid(decode_seg_map_sequence(torch.squeeze(target[:3], 1).detach().cpu().numpy(),
-                                                           dataset=dataset), 4, normalize=False, range=(0, 255))
+                                                           dataset=dataset), 4, normalize=False, value_range=(0, 255))
             writer.add_image('Groundtruth label', grid_image, global_step)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
The ERFNet training pipeline crashed on modern Python environments due to two separate execution failures involving deprecated APIs and subprocess module imports.

- Renamed the deprecated `range` keyword argument to `value_range` across all `torchvision.utils.make_grid()` calls in `utils/summaries.py` to restore compatibility with `torchvision >= 0.8.0`.
- Updated `self.workers = 0` within `TrainArgs` in `utils/args.py` to force PyTorch `DataLoader` to run in the main process. This prevents worker subprocesses from crashing with `ModuleNotFoundError` due to lost `sys.path` modifications.

**Which issue(s) this PR fixes:**
Fixes #472