### PR TITLE
fix: prevent NaN propagation in MOT17 tracking metrics

### DIFF
--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/idf1.py
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/idf1.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from collections import OrderedDict
 from pathlib import Path
 
@@ -46,4 +47,11 @@ def metric(y_true, y_pred):
     summary = mh.compute_many(accs, names=names, metrics=metrics_name, generate_overall=True)
     logger.info('Completed')
 
-    return round(float(summary.iloc[-1][metrics_name]), 4)
+    value = float(summary.iloc[-1][metrics_name])
+    if math.isnan(value) or math.isinf(value):
+        logger.warning(
+            "Metric '{}' returned {} (no valid detections?). Recording 0.0.",
+            metrics_name[0], value
+        )
+        return 0.0
+    return round(value, 4)

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/mota.py
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/mota.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from collections import OrderedDict
 from pathlib import Path
 
@@ -46,4 +47,11 @@ def metric(y_true, y_pred):
     summary = mh.compute_many(accs, names=names, metrics=metrics_name, generate_overall=True)
     logger.info('Completed')
 
-    return round(float(summary.iloc[-1][metrics_name]), 4)
+    value = float(summary.iloc[-1][metrics_name])
+    if math.isnan(value) or math.isinf(value):
+        logger.warning(
+            "Metric '{}' returned {} (no valid detections?). Recording 0.0.",
+            metrics_name[0], value
+        )
+        return 0.0
+    return round(value, 4)

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/motp.py
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/motp.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from collections import OrderedDict
 from pathlib import Path
 
@@ -46,4 +47,11 @@ def metric(y_true, y_pred):
     summary = mh.compute_many(accs, names=names, metrics=metrics_name, generate_overall=True)
     logger.info('Completed')
 
-    return round(float(summary.iloc[-1][metrics_name]), 4)
+    value = float(summary.iloc[-1][metrics_name])
+    if math.isnan(value) or math.isinf(value):
+        logger.warning(
+            "Metric '{}' returned {} (no valid detections?). Recording 0.0.",
+            metrics_name[0], value
+        )
+        return 0.0
+    return round(value, 4)

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/precision.py
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/precision.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from collections import OrderedDict
 from pathlib import Path
 
@@ -46,4 +47,11 @@ def metric(y_true, y_pred):
     summary = mh.compute_many(accs, names=names, metrics=metrics_name, generate_overall=True)
     logger.info('Completed')
 
-    return round(float(summary.iloc[-1][metrics_name]), 4)
+    value = float(summary.iloc[-1][metrics_name])
+    if math.isnan(value) or math.isinf(value):
+        logger.warning(
+            "Metric '{}' returned {} (no valid detections?). Recording 0.0.",
+            metrics_name[0], value
+        )
+        return 0.0
+    return round(value, 4)

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/recall.py
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/tracking/recall.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import math
 from collections import OrderedDict
 from pathlib import Path
 
@@ -46,4 +47,11 @@ def metric(y_true, y_pred):
     summary = mh.compute_many(accs, names=names, metrics=metrics_name, generate_overall=True)
     logger.info('Completed')
 
-    return round(float(summary.iloc[-1][metrics_name]), 4)
+    value = float(summary.iloc[-1][metrics_name])
+    if math.isnan(value) or math.isinf(value):
+        logger.warning(
+            "Metric '{}' returned {} (no valid detections?). Recording 0.0.",
+            metrics_name[0], value
+        )
+        return 0.0
+    return round(value, 4)


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it:**
When `motmetrics` cannot compute a value (e.g., zero valid detections), it outputs `NaN`. Previously, five upstream tracking metric scripts (`precision.py`, `recall.py`, `mota.py`, `motp.py`, `idf1.py`) blindly cast this output to float and returned it, which silently corrupted the `all_rank.csv` leaderboard with `NaN` values and broke numeric sorting. 

- Added a `math.isnan()` and `math.isinf()` guard to the final return statement in all five tracking metric scripts.
- When degenerate detection conditions occur, the pipeline now logs a warning and safely records `0.0` instead of corrupting the CSV downstream.
- Added `math` and `logging` imports to support the guard.

**Which issue(s) this PR fixes:**
Fixes #448