### PR TITLE
Fix rank picture mode without matrix

### DIFF
--- a/core/storymanager/rank/rank.py
+++ b/core/storymanager/rank/rank.py
@@ -236,6 +236,8 @@ class Rank:
             out_put = test_case.output_dir
             test_result = test_results[test_case.id][0]
             matrix = test_result.get("Matrix")
+            if not matrix:
+                continue
             for key in matrix.keys():
                 draw_heatmap_picture(out_put, key, matrix[key])
 


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`selected_and_all_and_picture` currently assumes every result has a `Matrix` metric.

For normal benchmarks with scalar metrics only, `_draw_pictures()` gets `None` and crashes on `matrix.keys()`, even though the rank CSV files can be saved.



**Which issue(s) this PR fixes**:

Fixes #559