### PR TITLE
fix: replace JsonlDataParse with JSONDataParse to match Sedna API

### DIFF
--- a/core/testenvmanager/dataset/dataset.py
+++ b/core/testenvmanager/dataset/dataset.py
@@ -22,8 +22,6 @@ from sedna.datasources import (
     CSVDataParse,
     TxtDataParse,
     JSONDataParse,
-    JsonlDataParse,
-    JSONMetaDataParse
 )
 
 from core.common import utils
@@ -575,20 +573,20 @@ class Dataset:
             data = CSVDataParse(data_type=data_type, func=feature_process)
             data.parse(file, label=label)
 
-        if data_format == DatasetFormat.TXT.value:
+        elif data_format == DatasetFormat.TXT.value:
             data = TxtDataParse(data_type=data_type, func=feature_process)
             data.parse(file, use_raw=use_raw)
 
-        if data_format == DatasetFormat.JSON.value:
+        elif data_format == DatasetFormat.JSON.value:
             data = JSONDataParse(data_type=data_type, func=feature_process)
             data.parse(file)
 
-        if data_format == DatasetFormat.JSONL.value:
-            data = JsonlDataParse(data_type=data_type, func=feature_process)
+        elif data_format == DatasetFormat.JSONL.value:
+            data = JSONDataParse(data_type=data_type, func=feature_process)
             data.parse(file)
 
-        if data_format == DatasetFormat.JSONFORLLM.value:
-            data = JSONMetaDataParse(data_type=data_type, func=feature_process)
+        elif data_format == DatasetFormat.JSONFORLLM.value:
+            data = JSONDataParse(data_type=data_type, func=feature_process)
             data.parse(file, **kwargs)
 
         return data


### PR DESCRIPTION
**What type of PR is this?**
/kind bug

**What this PR does / why we need it**:
`dataset.py` was importing `JsonlDataParse` and `JSONMetaDataParse` from 
`sedna.datasources`, but these names do not exist in current Sedna.
Sedna renamed `JsonlDataParse` to `JSONDataParse` and `JSONMetaDataParse` 
was never implemented. This caused an ImportError on every fresh install, 
which blocks all examples from running.

Changes:
- Replace `JsonlDataParse` with `JSONDataParse`
- Remove duplicate `JSONDataParse` import
- Replace `JSONMetaDataParse` with `JSONDataParse` as fallback for JSONFORLLM format

**Which issue(s) this PR fixes**:
Fixes #563