### PR TITLE
fix(core/federated): guard aggregation module lookup against None

### DIFF
--- a/core/testcasecontroller/algorithm/paradigm/federated_learning/federated_learning.py
+++ b/core/testcasecontroller/algorithm/paradigm/federated_learning/federated_learning.py
@@ -75,7 +75,14 @@ class FederatedLearning(ParadigmBase):
         self.aggregate_clients = []
         self.clients_number = kwargs.get("client_number", 1)
         self.mode = kwargs.get("if_mode_llm", False)
-        _, self.aggregator = self.module_instances.get(ModuleType.AGGREGATION.value)
+        _aggregation = self.module_instances.get(ModuleType.AGGREGATION.value)
+        if _aggregation is None:
+            raise ValueError(
+                "FederatedLearning requires an 'aggregation' module but none "
+                "was found. Add an 'aggregation' entry under 'modules:' in "
+                "your algorithm YAML."
+            )
+        _, self.aggregator = _aggregation
         if self.mode:
             LOGGER.info("Using LLM multi GPU mode for Federated Learning")
             self.gpu_num = kwargs.get("gpu_num", 1)

--- a/core/testcasecontroller/algorithm/paradigm/federated_learning/federated_learning.py
+++ b/core/testcasecontroller/algorithm/paradigm/federated_learning/federated_learning.py
@@ -76,11 +76,11 @@ class FederatedLearning(ParadigmBase):
         self.clients_number = kwargs.get("client_number", 1)
         self.mode = kwargs.get("if_mode_llm", False)
         _aggregation = self.module_instances.get(ModuleType.AGGREGATION.value)
-        if _aggregation is None:
+        if _aggregation is None or _aggregation[1] is None:
             raise ValueError(
                 "FederatedLearning requires an 'aggregation' module but none "
-                "was found. Add an 'aggregation' entry under 'modules:' in "
-                "your algorithm YAML."
+                "was found or successfully initialized. Add an 'aggregation' "
+                "entry under 'modules:' in your algorithm YAML."
             )
         _, self.aggregator = _aggregation
         if self.mode:


### PR DESCRIPTION
## Description
`FederatedLearning.__init__()` unpacks the result of 
`self.module_instances.get()` directly without a None guard. When the 
user's algorithm YAML omits the `aggregation` block, `.get()` returns 
`None` and Python crashes with:

TypeError: cannot unpack non-iterable NoneType object

This gives no hint about which module is missing or how to fix the YAML.

## Fix
Added a None guard that raises a descriptive `ValueError` pointing the 
user to the missing YAML entry before the unpack is attempted.

## File Changed
`core/testcasecontroller/algorithm/paradigm/federated_learning/federated_learning.py` line 78

## Testing
The fix is a pure guard — no behavior change on the happy path where 
aggregation module is present.

Fixes #565