### PR TITLE
fix: use elif in _write_data_file and _read_data_file to avoid redundant checks

### DIFF
--- a/core/testenvmanager/dataset/dataset.py
+++ b/core/testenvmanager/dataset/dataset.py
@@ -273,7 +273,7 @@ class Dataset:
             with open(data_file, "w", encoding="utf-8") as file:
                 for line in data:
                     file.writelines(line + "\n")
-        if data_format == DatasetFormat.CSV.value:
+        elif data_format == DatasetFormat.CSV.value:
             data.to_csv(data_file, index=None)
 
     @classmethod
@@ -284,7 +284,7 @@ class Dataset:
             with open(data_file, "r", encoding="utf-8") as file:
                 data = [line.strip() for line in file.readlines()]
 
-        if data_format == DatasetFormat.CSV.value:
+        elif data_format == DatasetFormat.CSV.value:
             data = pd.read_csv(data_file)
 
         return data

--- a/core/testenvmanager/dataset/dataset.py
+++ b/core/testenvmanager/dataset/dataset.py
@@ -275,6 +275,8 @@ class Dataset:
                     file.writelines(line + "\n")
         elif data_format == DatasetFormat.CSV.value:
             data.to_csv(data_file, index=None)
+        else:
+            raise ValueError(f"Unsupported data format for writing: {data_format}")
 
     @classmethod
     def _read_data_file(cls, data_file, data_format):
@@ -286,7 +288,8 @@ class Dataset:
 
         elif data_format == DatasetFormat.CSV.value:
             data = pd.read_csv(data_file)
-
+        else:
+            raise ValueError(f"Unsupported data format for reading: {data_format}")
         return data
 
     def _get_dataset_file(self, data, output_dir, dataset_type, index, dataset_format):


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
`_write_data_file` and `_read_data_file` in `dataset.py` used sequential 
`if` statements for mutually exclusive `data_format` checks. Since 
`data_format` can only match one value at a time, the second `if` block 
was always evaluated unnecessarily. Changed to `elif` to make the intent 
explicit and avoid redundant condition checks.

**Which issue(s) this PR fixes**:
Fixes #563