### PR TITLE
fix: add missing requirements.txt for government_rag and llm_simple_qa examples

### DIFF
--- a/examples/government_rag/requirements.txt
+++ b/examples/government_rag/requirements.txt
@@ -1,5 +1,7 @@
 torch>=2.0.0
 transformers>=4.30.0
+numpy>=1.24.0
+requests>=2.28.0
 langchain>=0.1.0
 langchain-community>=0.0.20
 chromadb>=0.4.0

--- a/examples/government_rag/requirements.txt
+++ b/examples/government_rag/requirements.txt
@@ -1,0 +1,7 @@
+torch>=2.0.0
+transformers>=4.30.0
+langchain>=0.1.0
+langchain-community>=0.0.20
+chromadb>=0.4.0
+tqdm>=4.65.0
+unstructured[docx]>=0.10.0

--- a/examples/llm_simple_qa/requirements.txt
+++ b/examples/llm_simple_qa/requirements.txt
@@ -1,0 +1,5 @@
+torch>=2.0.0
+transformers>=4.30.0
+numpy>=1.24.0
+mmengine>=0.8.0
+opencompass>=0.2.0


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
`government_rag` and `llm_simple_qa` examples had no `requirements.txt`, 
this causes new contributors to hit `ModuleNotFoundError` with no guidance 
on what to install. Both `llm-agent` and `llm-edge-benchmark-suite` 
already have requirements.txt,  this brings the remaining LLM examples 
to the same standard.

Added dependencies based on actual imports found in each example's 
basemodel.py and algorithm files.

**Which issue(s) this PR fixes**:
Fixes #563