### PR TITLE
fix(core/lifelong): correct rounds condition to fix HAS_COMPLETED_INITIAL_TRAINING in standard mode

### DIFF
--- a/core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py
+++ b/core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py
@@ -356,7 +356,7 @@ class LifelongLearning(ParadigmBase):
 
         os.environ["CLOUD_KB_INDEX"] = cloud_task_index
         os.environ["OUTPUT_URL"] = train_output_dir
-        if rounds < 1:
+        if rounds <= 1:
             os.environ["HAS_COMPLETED_INITIAL_TRAINING"] = 'False'
         else:
             os.environ["HAS_COMPLETED_INITIAL_TRAINING"] = 'True'

--- a/core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py
+++ b/core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py
@@ -356,10 +356,12 @@ class LifelongLearning(ParadigmBase):
 
         os.environ["CLOUD_KB_INDEX"] = cloud_task_index
         os.environ["OUTPUT_URL"] = train_output_dir
-        if rounds <= 1:
-            os.environ["HAS_COMPLETED_INITIAL_TRAINING"] = 'False'
+        mode = (self.model_eval_config or {}).get('model_metric', {}).get('mode')
+        is_initial = rounds < 1 if mode in ('no-inference', 'hard-example-mining') else rounds <= 1
+        if is_initial:
+            os.environ['HAS_COMPLETED_INITIAL_TRAINING'] = 'False'
         else:
-            os.environ["HAS_COMPLETED_INITIAL_TRAINING"] = 'True'
+            os.environ['HAS_COMPLETED_INITIAL_TRAINING'] = 'True'
 
         if isinstance(train_dataset, str):
             train_dataset = self.dataset.load_data(train_dataset, "train",


### PR DESCRIPTION
## Description

In standard benchmark mode (`elif mode != 'multi-inference'`), the
training loop starts at `r=1`. The `_train()` method uses `rounds < 1`
to determine whether initial training has completed. Since `1 < 1` is
always `False`, `HAS_COMPLETED_INITIAL_TRAINING` is set to `'True'`
on the very first call — before any training has occurred.

This is a silent correctness bug. Every lifelong learning algorithm
receives an incorrect signal on the first training round, causing it
to either attempt loading a non-existent checkpoint or skip
knowledge-base initialization. Benchmark metrics (BWT, FWT, Matrix)
are silently corrupted as a result.

## Root Cause

The condition `rounds < 1` only evaluates to `True` when `r=0`. The
standard mode loop starts at `r=1`, so the condition is never `True`
on the first call.

## Fix (final, mode-aware)

An initial one-line change (`rounds <= 1` unconditionally) was shown in
review to regress the zero-based `no-inference` and `hard-example-mining`
modes, whose first round starts at `r=0` rather than `r=1`.

The final implementation determines the correct predicate per mode:

    mode = (self.model_eval_config or {}).get('model_metric', {}).get('mode')
    is_initial = rounds < 1 if mode in ('no-inference', 'hard-example-mining') else rounds <= 1
    if is_initial:
        os.environ['HAS_COMPLETED_INITIAL_TRAINING'] = 'False'
    else:
        os.environ['HAS_COMPLETED_INITIAL_TRAINING'] = 'True'

This uses `rounds < 1` (original, preserved behavior) for the two
zero-based modes, and `rounds <= 1` (the actual fix) for standard mode,
which starts at `r=1`.

## Files Changed

- `core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py`

## Testing

Verified by reviewer zjr060424-lab against the full mode matrix
(standard, no-inference, hard-example-mining), confirming the fix
resolves the standard-mode defect without regressing the zero-based
modes. See review discussion below for details.

Fixes #572