### PR TITLE
fix: add missing requirements.txt for federated-llm example

### DIFF
--- a/examples/federated-llm/requirements.txt
+++ b/examples/federated-llm/requirements.txt
@@ -4,3 +4,4 @@ peft>=0.4.0
 tqdm>=4.65.0
 numpy>=1.24.0
 evaluate>=0.4.0
+rouge_score>=0.1.2

--- a/examples/federated-llm/requirements.txt
+++ b/examples/federated-llm/requirements.txt
@@ -1,0 +1,6 @@
+torch>=2.0.0
+transformers>=4.30.0
+peft>=0.4.0
+tqdm>=4.65.0
+numpy>=1.24.0
+evaluate>=0.4.0


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
`federated-llm` example had no `requirements.txt`, causing contributors 
to hit `ModuleNotFoundError` with no guidance. Added dependencies based 
on actual imports in `model.py`, `FedAvg-PEFT.py`, and `FedAvgM-PEFT.py`.

Dependencies added: torch, transformers, peft, tqdm, numpy, evaluate.

**Which issue(s) this PR fixes**:
Fixes #563