### PR TITLE
fix: add missing requirements.txt for smart_coding example

### DIFF
--- a/examples/smart_coding/requirements.txt
+++ b/examples/smart_coding/requirements.txt
@@ -1,0 +1,5 @@
+numpy>=1.24.0
+tqdm>=4.65.0
+openai>=1.0.0
+transformers>=4.30.0
+torch>=2.0.0


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
`smart_coding` example (both `comment` and `issue` sub-examples) had no 
`requirements.txt`. Contributors hit `ModuleNotFoundError` for numpy, 
tqdm, openai, and transformers with no guidance on what to install.

Dependencies identified from imports in:
- `comment/testalgorithms/gen/basemodel.py`
- `issue/testalgorithms/gen/basemodel.py`

**Which issue(s) this PR fixes**:
Fixes #563