### PR TITLE
fix: replace 'ianvs -f' with 'python benchmarking.py -f' in all example READMEs

### DIFF
--- a/examples/Cloud_Robotics/cloud-edge-collaborative-inference_bench/perception-reasoning/README.md
+++ b/examples/Cloud_Robotics/cloud-edge-collaborative-inference_bench/perception-reasoning/README.md
@@ -65,7 +65,7 @@ pip install examples/resources/third_party/sedna-0.6.0.1-py3-none-any.whl
 pip install -r requirements.txt
 
 # Install dependencies for this example.
-pip install -r examples/Cloud_Robotics/cloud-edge-collaborative-inference-bench/requirements.txt
+pip install -r examples/Cloud_Robotics/cloud-edge-collaborative-inference_bench/requirements.txt
 
 # Install ianvs
 python setup.py install  
@@ -161,7 +161,7 @@ Update the algorithm's **URL address** and **hyperparemeter** in the `perception
       # name of edge model module; string type;
       name: "EdgeModel"
       # the url address of edge model module; string type;
-      url: "./examples/Cloud_Robotics/cloud-edge-collaborative-inference-bench/perception-reasoning/testalgorithms/edge_model.py"
+      url: "./examples/Cloud_Robotics/cloud-edge-collaborative-inference_bench/perception-reasoning/testalgorithms/edge_model.py"
 
       hyperparameters:
       # name of the hyperparameter; string type;
@@ -173,7 +173,7 @@ Update the algorithm's **URL address** and **hyperparemeter** in the `perception
       # name of python module; string type;
       name: "CloudModel"
       # the url address of python module; string type;
-      url: "./examples/Cloud_Robotics/cloud-edge-collaborative-inference-bench/perception-reasoning/testalgorithms/cloud_model.py"
+      url: "./examples/Cloud_Robotics/cloud-edge-collaborative-inference_bench/perception-reasoning/testalgorithms/cloud_model.py"
 
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -197,7 +197,7 @@ Run Ianvs for benchmarking:
 ```bash
 cd /ianvs
 export DASHSCOPE_API_KEY="your_api_key_here"
-python benchmarking.py -f examples/Cloud_Robotics/cloud-edge-collaborative-inference-bench/perception-reasoning/benchmarkingjob.yaml
+python benchmarking.py -f examples/Cloud_Robotics/cloud-edge-collaborative-inference_bench/perception-reasoning/benchmarkingjob.yaml
 ```
 **Note**: Replace `"your_api_key_here"` with your actual Dashscope API key.
 

--- a/examples/Cloud_Robotics/cloud-edge-collaborative-inference_bench/perception-reasoning/README.md
+++ b/examples/Cloud_Robotics/cloud-edge-collaborative-inference_bench/perception-reasoning/README.md
@@ -197,7 +197,7 @@ Run Ianvs for benchmarking:
 ```bash
 cd /ianvs
 export DASHSCOPE_API_KEY="your_api_key_here"
-ianvs -f examples/Cloud_Robotics/cloud-edge-collaborative-inference-bench/perception-reasoning/benchmarkingjob.yaml
+python benchmarking.py -f examples/Cloud_Robotics/cloud-edge-collaborative-inference-bench/perception-reasoning/benchmarkingjob.yaml
 ```
 **Note**: Replace `"your_api_key_here"` with your actual Dashscope API key.
 

--- a/examples/GovDoc2Poster/singletask_learning_bench/README.md
+++ b/examples/GovDoc2Poster/singletask_learning_bench/README.md
@@ -138,7 +138,7 @@ cd /home/linux/Desktop/ianvs
 ### Step 3: Run the System
 
 ```bash
-ianvs -f examples/GovDoc2Poster/singletask_learning_bench/testalgorithms/gen/government_data_source.yaml
+python benchmarking.py -f examples/GovDoc2Poster/singletask_learning_bench/testalgorithms/gen/government_data_source.yaml
 ```
 
 ✅ Done! The system will automatically parse the government documents from the dataset and generate visual posters.

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/README.md
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/README.md
@@ -47,7 +47,7 @@ Next, download pretrained model via [[google]](https://drive.google.com/file/d/1
 We are now ready to run the ianvs for benchmarking pedestrian tracking on the MOT17 dataset.
 
 ```python
-ianvs -f ./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/tracking_job.yaml
+python benchmarking.py -f ./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/tracking_job.yaml
 ```
 
 The benchmarking process takes a few minutes and varies depending on devices.
@@ -78,7 +78,7 @@ Next, download pretrained model via [[google]](https://drive.google.com/drive/fo
 We are now ready to run the ianvs for benchmarking pedestrian re-identification on the MOT17 dataset.
 
 ```python
-ianvs -f ./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/reid_job.yaml
+python benchmarking.py -f ./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/reid_job.yaml
 ```
 
 The benchmarking process takes a few minutes and varies depending on devices.

--- a/examples/PIPL/edge-cloud_collaborative_learning_bench/README.md
+++ b/examples/PIPL/edge-cloud_collaborative_learning_bench/README.md
@@ -115,7 +115,7 @@ export CLOUD_API_KEY="your_cloud_model_api_key"
 
 3. Run benchmark:
 ```bash
-ianvs -f benchmarkingjob.yaml
+python benchmarking.py -f benchmarkingjob.yaml
 ```
 
 ## Evaluation Methods

--- a/examples/PIPL/edge-cloud_collaborative_learning_bench/README.md
+++ b/examples/PIPL/edge-cloud_collaborative_learning_bench/README.md
@@ -115,7 +115,8 @@ export CLOUD_API_KEY="your_cloud_model_api_key"
 
 3. Run benchmark:
 ```bash
-python benchmarking.py -f benchmarkingjob.yaml
+cd examples/PIPL/edge-cloud_collaborative_learning_bench
+python ../../../benchmarking.py -f benchmarkingjob.yaml
 ```
 
 ## Evaluation Methods

--- a/examples/bdd/lifelong_learning_bench/curb-detection/README.md
+++ b/examples/bdd/lifelong_learning_bench/curb-detection/README.md
@@ -115,7 +115,7 @@ We are now ready to run the ianvs for benchmarking.
 
 ``` shell
 cd /ianvs/project
-ianvs -f examples/bdd/lifelong_learning_bench/curb-detection/benchmarkingjob.yaml
+python benchmarking.py -f examples/bdd/lifelong_learning_bench/curb-detection/benchmarkingjob.yaml
 ```
 
 Finally, the user can check the result of benchmarking on the console and also in the output path(

--- a/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/README.md
+++ b/examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/README.md
@@ -80,7 +80,7 @@ We are now ready to run the ianvs for benchmarking.
 
 ``` shell
 cd /ianvs/project/ianvs
-ianvs -f examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/benchmarkingjob.yaml
+python benchmarking.py -f examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/benchmarkingjob.yaml
 ```
 
 Finally, the user can check the result of benchmarking on the console and also in the output path(

--- a/examples/cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/README.md
+++ b/examples/cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/README.md
@@ -86,7 +86,7 @@ We are now ready to run the ianvs for benchmarking.
 
 ``` shell
 cd /ianvs/project/ianvs
-ianvs -f examples/cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/benchmarkingjob-smalltest.yaml
+python benchmarking.py -f examples/cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/benchmarkingjob-smalltest.yaml
 ```
 
 Finally, the user can check the result of benchmarking on the console and also in the output path(

--- a/examples/cloud-edge-collaborative-inference-for-llm/README.md
+++ b/examples/cloud-edge-collaborative-inference-for-llm/README.md
@@ -141,7 +141,7 @@ export OPENAI_API_KEY=sk_xxxxxxxx
 
 6. Run the Ianvs benchmark:
 ```bash 
-ianvs -f examples/cloud-edge-collaborative-inference-for-llm/benchmarkingjob.yaml
+python benchmarking.py -f examples/cloud-edge-collaborative-inference-for-llm/benchmarkingjob.yaml
 ```
 
 *Note: To help you get results quickly, we have provided a workspace folder with cached results for `Qwen/Qwen2.5-1.5B-Instruct`, `Qwen/Qwen2.5-3B-Instruct`,`Qwen/Qwen2.5-7B-Instruct` and `gpt-4o-mini`.*
@@ -352,7 +352,7 @@ You can download `workspace-mmlu` folder from [Ianvs-MMLU-5-shot](https://www.ka
 
 Run the following command:
 
-`ianvs -f examples/cloud-edge-collaborative-inference-for-llm/benchmarkingjob.yaml`
+`python benchmarking.py -f examples/cloud-edge-collaborative-inference-for-llm/benchmarkingjob.yaml`
 
 After the process finished, you will see output like this:
 

--- a/examples/cloud-edge-speculative-decoding-benchmark/README.md
+++ b/examples/cloud-edge-speculative-decoding-benchmark/README.md
@@ -182,13 +182,13 @@ Common options include:
 Run the `AR` benchmark:
 
 ```bash
-ianvs -f examples/cloud-edge-speculative-decoding-benchmark/benchmarkingjob.yaml
+python benchmarking.py -f examples/cloud-edge-speculative-decoding-benchmark/benchmarkingjob.yaml
 ```
 
 Run the `Block` benchmark:
 
 ```bash
-ianvs -f examples/cloud-edge-speculative-decoding-benchmark/benchmarkingjob_block.yaml
+python benchmarking.py -f examples/cloud-edge-speculative-decoding-benchmark/benchmarkingjob_block.yaml
 ```
 
 Benchmark outputs are written under the workspace configured in each benchmarking job file:

--- a/examples/cloud_VLA_finetune/singletask_learning_bench/README.md
+++ b/examples/cloud_VLA_finetune/singletask_learning_bench/README.md
@@ -310,7 +310,7 @@ Run the following command:
 
 ```
 cd ianvs
-ianvs -f /examples/cloud_VLA_finetune/singletask_learning_bench/benchmarkingjob.yaml
+python benchmarking.py -f /examples/cloud_VLA_finetune/singletask_learning_bench/benchmarkingjob.yaml
 ```
 
 After the process finished, you will see output like this:

--- a/examples/federated-llm/fedllm-peft/README.md
+++ b/examples/federated-llm/fedllm-peft/README.md
@@ -246,7 +246,7 @@ Each line should be a valid JSON object with at least two fields representing th
 Execute the federated LLM fine-tuning benchmark:
 
 ```bash
-ianvs -f ./examples/federated-llm/fedllm-peft/benchmarkingjob.yaml
+python benchmarking.py -f ./examples/federated-llm/fedllm-peft/benchmarkingjob.yaml
 ```
 
 **Important**: Please change the path to `benchmarkingjob.yaml` as per your setup.

--- a/examples/government/singletask_learning_bench/README.md
+++ b/examples/government/singletask_learning_bench/README.md
@@ -97,8 +97,8 @@ Or you can replace the file in `yourpath/anaconda3/envs/ianvs/lib/python3.x/site
 
 ### Objective
 
-`ianvs -f examples/government/singletask_learning_bench/objective/benchmarkingjob.yaml`
+`python benchmarking.py -f examples/government/singletask_learning_bench/objective/benchmarkingjob.yaml`
 
 ### Subjective
 
-`ianvs -f examples/government/singletask_learning_bench/subjective/benchmarkingjob.yaml`
+`python benchmarking.py -f examples/government/singletask_learning_bench/subjective/benchmarkingjob.yaml`

--- a/examples/government_rag/README.md
+++ b/examples/government_rag/README.md
@@ -72,7 +72,7 @@ For each region's evaluation, we have four experimental designs (Type 1, 2, 3, 4
 
 2. Run the test:
    ```bash
-   ianvs -f examples/government_rag/singletask_learning_bench/benchmarkingjob.yaml
+   python benchmarking.py -f examples/government_rag/singletask_learning_bench/benchmarkingjob.yaml
    ```
 
 ## Test Results

--- a/examples/imagenet/multiedge_inference_bench/README.md
+++ b/examples/imagenet/multiedge_inference_bench/README.md
@@ -44,7 +44,7 @@ Next, download pretrained model via [[huggingface]](https://huggingface.co/optim
 We are now ready to run the ianvs for benchmarking image classification for high mobility scenarios on the ImageNet dataset.
 
 ```python
-ianvs -f ./examples/imagenet/multiedge_inference_bench/classification_job_manual.yaml
+python benchmarking.py -f ./examples/imagenet/multiedge_inference_bench/classification_job_manual.yaml
 ```
 
 The benchmarking process takes a few minutes and varies depending on devices.
@@ -75,7 +75,7 @@ Then you will find a profiler_results.yml file in the <Ianvs_HOME>/examples/imag
 
 Then you can run the following command to perform benchmarking:
 ```shell
-ianvs -f ./examples/imagenet/multiedge_inference_bench/classification_job_auto.yaml
+python benchmarking.py -f ./examples/imagenet/multiedge_inference_bench/classification_job_auto.yaml
 ```
 
 After running, you will see the profit from the automatic method compared with the manual method.

--- a/examples/industrialEI/pose-estimation-llio/README.md
+++ b/examples/industrialEI/pose-estimation-llio/README.md
@@ -140,7 +140,7 @@ pose-estimation-llio/
 
 5. **Run Benchmarking**:
    ```bash
-   ianvs -f examples/industrialEI/pose-estimation-llio/benchmarkingjob.yaml
+   python benchmarking.py -f examples/industrialEI/pose-estimation-llio/benchmarkingjob.yaml
    ```
 
 ## Configuration

--- a/examples/industrialEI/single_task_learning_bench/deformable_component_manipulation/README.md
+++ b/examples/industrialEI/single_task_learning_bench/deformable_component_manipulation/README.md
@@ -224,7 +224,7 @@ Execute the benchmark:
 
 ```shell
 cd /ianvs
-ianvs -f examples/industrialEI/single_task_learning_bench/deformable_assembly/benchmarkingjob.yaml
+python benchmarking.py -f examples/industrialEI/single_task_learning_bench/deformable_assembly/benchmarkingjob.yaml
 ```
 
 

--- a/examples/llm-agent/singletask_learning_bench/README.md
+++ b/examples/llm-agent/singletask_learning_bench/README.md
@@ -36,7 +36,7 @@ pip install -r examples/llm-agent/singletask_learning_bench/requirements.txt
 #    pipeline works.
 
 # 5. Run the benchmark
-ianvs -f examples/llm-agent/singletask_learning_bench/benchmarkingjob.yaml
+python benchmarking.py -f examples/llm-agent/singletask_learning_bench/benchmarkingjob.yaml
 ```
 
 First run is slow because HuggingFace downloads `Langboat/bloom-1b4-zh` (~3 GB) into `~/.cache/huggingface`. Subsequent runs use the cache and start immediately.

--- a/examples/llm-edge-benchmark-suite/README.md
+++ b/examples/llm-edge-benchmark-suite/README.md
@@ -31,11 +31,11 @@ python setup.py install
 
 
 ```shell
-ianvs -f examples/llm-edge-benchmark-suite/single_task_bench/benchmarkingjob.yaml
+python benchmarking.py -f examples/llm-edge-benchmark-suite/single_task_bench/benchmarkingjob.yaml
 ```
 
 
 ```shell
-ianvs -f examples/llm-edge-benchmark-suite/single_task_bench_with_compression/benchmarkingjob.yaml
+python benchmarking.py -f examples/llm-edge-benchmark-suite/single_task_bench_with_compression/benchmarkingjob.yaml
 ```
 

--- a/examples/llm-edge-benchmark-suite/single_task_bench/README.md
+++ b/examples/llm-edge-benchmark-suite/single_task_bench/README.md
@@ -173,7 +173,7 @@ during pipeline execution.
 From `$REPO_ROOT`:
 
 ```bash
-ianvs -f examples/llm-edge-benchmark-suite/single_task_bench/benchmarkingjob.yaml
+python benchmarking.py -f examples/llm-edge-benchmark-suite/single_task_bench/benchmarkingjob.yaml
 ```
 
 Ianvs loads the configs, instantiates `LlamaCppModel`, streams inference over

--- a/examples/llm-edge-benchmark-suite/single_task_bench_with_compression/README.md
+++ b/examples/llm-edge-benchmark-suite/single_task_bench_with_compression/README.md
@@ -50,7 +50,7 @@ dataset:
 Once all paths are absolute and the script is updated, execute the benchmark:
 
 ```bash
-ianvs -f ianvs/examples/llm-edge-benchmark-suite/single_task_bench_with_compression/benchmarkingjob.yaml
+python benchmarking.py -f ianvs/examples/llm-edge-benchmark-suite/single_task_bench_with_compression/benchmarkingjob.yaml
 ```
 
 ### Expected Output

--- a/examples/llm_simple_qa/README.md
+++ b/examples/llm_simple_qa/README.md
@@ -4,15 +4,7 @@
 
 ### Prepare Data
 
-From the repository root, run:
-
-`python examples/llm_simple_qa/scripts/02_prepare_dataset.py`
-
-For a smoke test, generate a single test row:
-
-`python examples/llm_simple_qa/scripts/02_prepare_dataset.py --smoke`
-
-The script creates the following structure by default:
+The data of simple-qa example structure is:
 
 ```
 .
@@ -22,43 +14,71 @@ The script creates the following structure by default:
     └── data.jsonl
 ```
 
-`train_data/data.jsonl` is empty.
+`train_data/data.jsonl` is empty, and the `test_data/data.jsonl` is as follows:
 
-`test_data/data.jsonl` contains generated JSONL rows, one JSON object per line. By default it writes 10 rows; `--smoke` writes 1 row.
-
-Example output for the default run:
-
-```json
-{"question":"If Xiao Ming has 5 apples, and he gives 3 to Xiao Hua, how many apples does Xiao Ming have left?\nA. 2\nB. 3\nC. 4\nD. 5","answer":"A"}
-{"question":"Which of the following numbers is the smallest prime number?\nA. 0\nB. 1\nC. 2\nD. 4","answer":"C"}
-{"question":"A rectangle has a length of 10 centimeters and a width of 5 centimeters, what is its perimeter in centimeters?\nA. 20 centimeters\nB. 30 centimeters\nC. 40 centimeters\nD. 50 centimeters","answer":"B"}
+```
+{
+  "question": "If Xiao Ming has 5 apples, and he gives 3 to Xiao Hua, how many apples does Xiao Ming have left?\nA. 2\nB. 3\nC. 4\nD. 5",
+  "answer": "A"
+}
+{
+  "question": "Which of the following numbers is the smallest prime number?\nA. 0\nB. 1\nC. 2\nD. 4",
+  "answer": "C"
+}
+{
+  "question": "A rectangle has a length of 10 centimeters and a width of 5 centimeters, what is its perimeter in centimeters?\nA. 20 centimeters\nB. 30 centimeters\nC. 40 centimeters\nD. 50 centimeters",
+  "answer": "B"
+}
+{
+  "question": "Which of the following fractions is closest to 1?\nA. 1/2\nB. 3/4\nC. 4/5\nD. 5/6",
+  "answer": "D"
+}
+{
+  "question": "If a number plus 10 equals 30, what is the number?\nA. 20\nB. 21\nC. 22\nD. 23",
+  "answer": "A"
+}
+{
+  "question": "Which of the following expressions has the largest result?\nA. 3 + 4\nB. 5 - 2\nC. 6 * 2\nD. 7 ÷ 2",
+  "answer": "C"
+}
+{
+  "question": "A class has 24 students, and if each student brings 2 books, how many books are there in total?\nA. 48\nB. 36\nC. 24\nD. 12",
+  "answer": "A"
+}
+{
+  "question": "Which of the following is the correct multiplication rhyme?\nA. Three threes are seven\nB. Four fours are sixteen\nC. Five fives are twenty-five\nD. Six sixes are thirty-six",
+  "answer": "B"
+}
+{
+  "question": "If one number is three times another number, and this number is 15, what is the other number?\nA. 5\nB. 10\nC. 15\nD. 45",
+  "answer": "A"
+}
+{
+  "question": "Which of the following shapes has the longest perimeter?\nA. Square\nB. Rectangle\nC. Circle\nD. Triangle",
+  "answer": "C"
+}
 ```
 
 ### Prepare Environment
 
-Install the example dependencies first:
+You need to install the changed-sedna package, which added `JsonlDataParse` in `sedna.datasources`
 
-`cd examples/llm_simple_qa && scripts/01_install_requirements.sh requirements.txt`
-
-Install Sedna from the bundled wheel:
-
-`pip install resources/third_party/sedna-0.6.0.1-py3-none-any.whl`
+Replace the file in `yourpath/anaconda3/envs/ianvs/lib/python3.x/site-packages/sedna` with `examples/resources/sedna-with-jsonl.zip`
 
 
 ### Run Ianvs
 
 Run the following command:
 
-`ianvs -f examples/llm_simple_qa/benchmarkingjob.yaml`
+`python benchmarking.py -f examples/llm/singletask_learning_bench/simple_qa/benchmarkingjob.yaml`
 
 ## OpenCompass Evaluation
 
 ### Prepare Environment
 
-Install OpenCompass from pip:
-
-`pip install -U opencompass`
+`pip install examples/resources/opencompass-0.2.5-py3-none-any.whl`
 
 ### Run Evaluation
 
-`python run_op.py examples/llm_simple_qa/testalgorithms/gen/op_eval.py`
+`python run_op.py examples/llm/singletask_learning_bench/simple_qa/testalgorithms/gen/op_eval.py`
+

--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/README.md
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/README.md
@@ -77,7 +77,7 @@ We are now ready to run the ianvs for benchmarking.
 
 ``` shell
 cd /ianvs/project
-ianvs -f examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/benchmarkingjob.yaml
+python benchmarking.py -f examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/benchmarkingjob.yaml
 ```
 
 Finally, the user can check the result of benchmarking on the console and also in the output path(

--- a/examples/robot/lifelong_learning_bench/semantic-segmentation/README.md
+++ b/examples/robot/lifelong_learning_bench/semantic-segmentation/README.md
@@ -130,7 +130,7 @@ To run the basic lifelong learning process:
 
 ```shell
 cd /ianvs/project/ianvs
-ianvs -f examples/robot/lifelong_learning_bench/semantic-segmentation/benchmarkingjob-simple.yaml
+python benchmarking.py -f examples/robot/lifelong_learning_bench/semantic-segmentation/benchmarkingjob-simple.yaml
 ```
 
 Finally, the user can check the result of benchmarking on the console and also in the output path(
@@ -148,7 +148,7 @@ To run the large vision model based cloud-edge collaboration process:
 
 ```shell
 cd /ianvs/project/ianvs
-ianvs -f examples/robot/lifelong_learning_bench/semantic-segmentation/benchmarkingjob-sam.yaml
+python benchmarking.py -f examples/robot/lifelong_learning_bench/semantic-segmentation/benchmarkingjob-sam.yaml
 ```
 
 Finally, the user can check the result of benchmarking on the console and also in the output path(

--- a/examples/smart_coding/smart_coding_learning_bench/README.md
+++ b/examples/smart_coding/smart_coding_learning_bench/README.md
@@ -107,8 +107,8 @@ Or you can replace the file in `yourpath/anaconda3/envs/ianvs/lib/python3.x/site
 
 ### Comment
 
-`ianvs -f examples/smart_coding/smart_coding_learning_bench/comment/benchmarkingjob.yaml`
+`python benchmarking.py -f examples/smart_coding/smart_coding_learning_bench/comment/benchmarkingjob.yaml`
 
 ### Issue
 
-`ianvs -f examples/smart_coding/smart_coding_learning_bench/issue/benchmarkingjob.yaml`
+`python benchmarking.py -f examples/smart_coding/smart_coding_learning_bench/issue/benchmarkingjob.yaml`


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
24 example READMEs instructed users to run `ianvs -f` which fails on 
a fresh install with `No module named ianvs`. The correct command is 
`python benchmarking.py -f`.

This is a systematic fix across all affected READMEs found via:
`find examples -name "README.md" | xargs grep -l "ianvs -f"`

Files changed: 24 READMEs, 34 occurrences replaced.

**Which issue(s) this PR fixes**:
Fixes #563