### PR TITLE
fix: add requirements.txt and replace hardcoded paths in government example

### DIFF
--- a/examples/government/requirements.txt
+++ b/examples/government/requirements.txt
@@ -1,0 +1,5 @@
+torch>=2.0.0
+transformers>=4.30.0
+numpy>=1.24.0
+tqdm>=4.65.0
+openai>=1.0.0

--- a/examples/government/singletask_learning_bench/objective/benchmarkingjob.yaml
+++ b/examples/government/singletask_learning_bench/objective/benchmarkingjob.yaml
@@ -2,7 +2,7 @@ benchmarkingjob:
   # job name of bechmarking; string type;
   name: "benchmarkingjob"
   # the url address of job workspace that will reserve the output of tests; string type;
-  workspace: "/home/icyfeather/project/ianvs/workspace"
+  workspace: "./workspace"
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;

--- a/examples/government/singletask_learning_bench/objective/testenv/testenv.yaml
+++ b/examples/government/singletask_learning_bench/objective/testenv/testenv.yaml
@@ -2,9 +2,9 @@ testenv:
   # dataset configuration
   dataset:
     # the url address of train dataset index; string type;
-    train_data: "/home/icyfeather/Projects/ianvs/dataset/government/objective/train_data/data.jsonl"
+    train_data: "./dataset/government/objective/train_data/data.jsonl"
     # the url address of test dataset index; string type;
-    test_data_info: "/home/icyfeather/Projects/ianvs/dataset/government/objective/test_data/metadata.json"
+    test_data_info: "./dataset/government/objective/test_data/metadata.json"
 
   # metrics configuration for test case's evaluation; list type;
   metrics:

--- a/examples/government/singletask_learning_bench/subjective/benchmarkingjob.yaml
+++ b/examples/government/singletask_learning_bench/subjective/benchmarkingjob.yaml
@@ -2,7 +2,7 @@ benchmarkingjob:
   # job name of bechmarking; string type;
   name: "benchmarkingjob"
   # the url address of job workspace that will reserve the output of tests; string type;
-  workspace: "/home/icyfeather/project/ianvs/workspace"
+  workspace: "./workspace"
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;

--- a/examples/government/singletask_learning_bench/subjective/testenv/testenv.yaml
+++ b/examples/government/singletask_learning_bench/subjective/testenv/testenv.yaml
@@ -2,9 +2,9 @@ testenv:
   # dataset configuration
   dataset:
     # the url address of train dataset index; string type;
-    train_data: "/home/icyfeather/Projects/ianvs/dataset/government/subjective/train_data/data.jsonl"
+    train_data: "./dataset/government/subjective/train_data/data.jsonl"
     # the url address of test dataset index; string type;
-    test_data_info: "/home/icyfeather/Projects/ianvs/dataset/government/subjective/test_data/metadata.json"
+    test_data_info: "./dataset/government/subjective/test_data/metadata.json"
 
   # metrics configuration for test case's evaluation; list type;
   metrics:


### PR DESCRIPTION
**What type of PR is this?**
/kind documentation

**What this PR does / why we need it**:
The `government` example had two issues:

1. No `requirements.txt` — contributors hit `ModuleNotFoundError` for 
torch, transformers, numpy, tqdm, and openai with no guidance.

2. Hardcoded absolute paths (`/home/icyfeather/...`) in 4 YAML files 
(2 benchmarkingjob.yaml, 2 testenv.yaml) making benchmarks non-runnable 
on any machine except the original developer's.

Both `objective` and `subjective` sub-examples are fixed.

**Which issue(s) this PR fixes**:
Fixes #563