### PR TITLE
fix(multiedge-inference-bench): consolidate fixes for MOT17 and robot-cityscapes-synthia examples

### DIFF
--- a/core/testcasecontroller/algorithm/paradigm/multiedge_inference/multiedge_inference.py
+++ b/core/testcasecontroller/algorithm/paradigm/multiedge_inference/multiedge_inference.py
@@ -17,7 +17,6 @@
 import os
 
 # pylint: disable=E0401
-import onnx
 
 from core.common.log import LOGGER
 from core.common.constant import ParadigmType
@@ -99,6 +98,14 @@ class MultiedgeInference(ParadigmBase):
 
     # pylint: disable=W0718, C0103
     def _partition(self, partition_point_list, initial_model_path, sub_model_dir):
+        # Fix #450: lazy import — only needed for model partitioning path
+        try:
+            import onnx  # pylint: disable=import-outside-toplevel
+        except ImportError as e:
+            raise ImportError(
+                "onnx is required for model partitioning but is not installed. "
+                "Install with: pip install onnx"
+            ) from e
         map_info = dict({})
         for idx, point in enumerate(partition_point_list):
             input_names = point['input_names']

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/README.md
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/README.md
@@ -51,7 +51,7 @@ ianvs -f ./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/tracking
 ```
 
 The benchmarking process takes a few minutes and varies depending on devices.
-Finally, the user can check the result of benchmarking on the console and also in the output path( /ianvs/multiedge_inference_bench/workspace) defined in the benchmarking config file ( tracking_job.yaml).
+Finally, the user can check the result of benchmarking on the console and also in the output path( ./workspace/multiedge_inference_bench) defined in the benchmarking config file ( tracking_job.yaml).
 The final output might look like this:
 
 |rank  |algorithm                | mota | f1_score  |motp  |recall  |idf1  |precision  |paradigm            |basemodel  |batch_size  |time                     |url                                                                                                                             |
@@ -82,7 +82,7 @@ ianvs -f ./examples/MOT17/multiedge_inference_bench/pedestrian_tracking/reid_job
 ```
 
 The benchmarking process takes a few minutes and varies depending on devices.
-Finally, the user can check the result of benchmarking on the console and also in the output path( /ianvs/multiedge_inference_bench/workspace) defined in the benchmarking config file ( reid_job.yaml).
+Finally, the user can check the result of benchmarking on the console and also in the output path( ./workspace/multiedge_inference_bench) defined in the benchmarking config file ( reid_job.yaml).
 The final output might look like this:
 
 |rank  |algorithm                |rank_1  |mAP  |cmc  |rank_2  |rank_5  |paradigm            |basemodel  |batch_size  |time                     |url                                                                                                                             |

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/reid_job.yaml
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/reid_job.yaml
@@ -2,7 +2,7 @@ benchmarkingjob:
   # job name of benchmarking; string type;
   name: "reid_job"
   # the url address of job workspace that will reserve the output of tests; string type;
-  workspace: "/ianvs/multiedge_inference_bench/workspace"
+  workspace: "./workspace/multiedge_inference_bench"
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/requirements.txt
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/requirements.txt
@@ -1,0 +1,18 @@
+# Requirements for MOT17/multiedge_inference_bench
+# Fix #449: added missing packages (loguru, motmetrics, mmcv, opencv-python)
+# that caused repeated ImportError cycles for new contributors.
+#
+# Version bounds:
+#   motmetrics>=1.2.0  — 1.x and 0.x have incompatible metric field names
+#   pandas<2.0         — generate_reports.py uses deprecated delim_whitespace=True
+#
+# Note: ByteTrack must be installed separately from source (see README).
+motmetrics>=1.2.0
+loguru
+fpdf
+pandas>=1.3.0,<2.0
+seaborn
+scikit-learn
+scipy
+opencv-python
+mmcv

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/reid/mAP.py
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/reid/mAP.py
@@ -12,35 +12,37 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
 import numpy as np
-from sklearn.metrics import average_precision_score
-from sedna.common.class_factory import ClassType, ClassFactory
-
-__all__ = ["mAP"]
+from core.common.log import LOGGER
 
 
 def mean_ap(distmat, query_ids, gallery_ids):
     m, _ = distmat.shape
-    # Sort and find correct matches
     indices = np.argsort(distmat, axis=1)
     matches = (gallery_ids[indices] == query_ids[:, np.newaxis])
-    # Compute AP for each query
     aps = []
     for i in range(m):
-        y_true = matches[i]
-        y_score = -distmat[i][indices[i]]
-        if not np.any(y_true): 
+        valid = matches[i]
+        if not valid.any():
+            # No gallery match for this query — skip gracefully.
             continue
-        aps.append(average_precision_score(y_true, y_score))
+        tps = np.cumsum(valid)
+        precision_at_k = tps / (np.arange(len(valid)) + 1)
+        ap = (precision_at_k * valid).sum() / valid.sum()
+        aps.append(ap)
+
     if len(aps) == 0:
-        raise RuntimeError("No valid query")
+        # Fix #447: replaced RuntimeError("No valid query") with a warning
+        # and graceful 0.0 return so the pipeline does not crash.
+        LOGGER.warning(
+            "mAP: no valid queries found (no query identity appears in the "
+            "gallery). Returning mAP=0.0. Check that query/gallery splits "
+            "share at least one common identity."
+        )
+        return 0.0
+
     return round(float(np.mean(aps)), 4)
 
 
-@ClassFactory.register(ClassType.GENERAL, alias="mAP")
-def mAP(query_ids, pred):
-    query_ids = np.asarray([int(y.split('/')[-1]) for y in query_ids])
-    distmat, gallery_ids = pred
-    return mean_ap(distmat, query_ids, gallery_ids)
+def mAP(y_pred, y_true, **kwargs):
+    return mean_ap(y_pred, y_true[:, 0], y_true[:, 1])

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/reid/rank_1.py
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/reid/rank_1.py
@@ -12,30 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
 import numpy as np
-from sedna.common.class_factory import ClassType, ClassFactory
-
-__all__ = ["rank_1"]
 
 
 def cmc(distmat, query_ids, gallery_ids, topk):
     m, _ = distmat.shape
-    # Sort and find correct matches
     indices = np.argsort(distmat, axis=1)
     matches = (gallery_ids[indices] == query_ids[:, np.newaxis])
-    # Compute CMC for each query
     ret = np.zeros(topk)
     for i in range(m):
-        k = np.nonzero(matches[i])[0][0]
+        nonzero = np.nonzero(matches[i])[0]
+        # Fix #447: skip queries with no matching identity in the gallery.
+        # np.nonzero()[0][0] raised IndexError on empty arrays before this fix.
+        if len(nonzero) == 0:
+            continue
+        k = nonzero[0]
         if k < topk:
             ret[k] += 1
     return round(float(ret.cumsum()[-1] / m), 4)
 
 
-@ClassFactory.register(ClassType.GENERAL, alias="rank_1")
-def rank_1(query_ids, pred):
-    query_ids = np.asarray([int(y.split('/')[-1]) for y in query_ids])
-    distmat, gallery_ids = pred
-    return cmc(distmat, query_ids, gallery_ids, 1)
+def rank_1(y_pred, y_true, **kwargs):
+    return cmc(y_pred, y_true[:, 0], y_true[:, 1], topk=1)

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/reid/rank_2.py
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/reid/rank_2.py
@@ -12,30 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
 import numpy as np
-from sedna.common.class_factory import ClassType, ClassFactory
-
-__all__ = ["rank_2"]
 
 
 def cmc(distmat, query_ids, gallery_ids, topk):
     m, _ = distmat.shape
-    # Sort and find correct matches
     indices = np.argsort(distmat, axis=1)
     matches = (gallery_ids[indices] == query_ids[:, np.newaxis])
-    # Compute CMC for each query
     ret = np.zeros(topk)
     for i in range(m):
-        k = np.nonzero(matches[i])[0][0]
+        nonzero = np.nonzero(matches[i])[0]
+        # Fix #447: skip queries with no matching identity in the gallery.
+        # np.nonzero()[0][0] raised IndexError on empty arrays before this fix.
+        if len(nonzero) == 0:
+            continue
+        k = nonzero[0]
         if k < topk:
             ret[k] += 1
     return round(float(ret.cumsum()[-1] / m), 4)
 
 
-@ClassFactory.register(ClassType.GENERAL, alias="rank_2")
-def rank_2(query_ids, pred):
-    query_ids = np.asarray([int(y.split('/')[-1]) for y in query_ids])
-    distmat, gallery_ids = pred
-    return cmc(distmat, query_ids, gallery_ids, 2)
+def rank_2(y_pred, y_true, **kwargs):
+    return cmc(y_pred, y_true[:, 0], y_true[:, 1], topk=2)

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/reid/rank_5.py
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/testenv/reid/rank_5.py
@@ -12,30 +12,25 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from __future__ import absolute_import
-
 import numpy as np
-from sedna.common.class_factory import ClassType, ClassFactory
-
-__all__ = ["rank_5"]
 
 
 def cmc(distmat, query_ids, gallery_ids, topk):
     m, _ = distmat.shape
-    # Sort and find correct matches
     indices = np.argsort(distmat, axis=1)
     matches = (gallery_ids[indices] == query_ids[:, np.newaxis])
-    # Compute CMC for each query
     ret = np.zeros(topk)
     for i in range(m):
-        k = np.nonzero(matches[i])[0][0]
+        nonzero = np.nonzero(matches[i])[0]
+        # Fix #447: skip queries with no matching identity in the gallery.
+        # np.nonzero()[0][0] raised IndexError on empty arrays before this fix.
+        if len(nonzero) == 0:
+            continue
+        k = nonzero[0]
         if k < topk:
             ret[k] += 1
     return round(float(ret.cumsum()[-1] / m), 4)
 
 
-@ClassFactory.register(ClassType.GENERAL, alias="rank_5")
-def rank_5(query_ids, pred):
-    query_ids = np.asarray([int(y.split('/')[-1]) for y in query_ids])
-    distmat, gallery_ids = pred
-    return cmc(distmat, query_ids, gallery_ids, 5)
+def rank_5(y_pred, y_true, **kwargs):
+    return cmc(y_pred, y_true[:, 0], y_true[:, 1], topk=5)

--- a/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/tracking_job.yaml
+++ b/examples/MOT17/multiedge_inference_bench/pedestrian_tracking/tracking_job.yaml
@@ -2,7 +2,7 @@ benchmarkingjob:
   # job name of benchmarking; string type;
   name: "tracking_job"
   # the url address of job workspace that will reserve the output of tests; string type;
-  workspace: "/ianvs/multiedge_inference_bench/workspace"
+  workspace: "./workspace/multiedge_inference_bench"
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;

--- a/examples/imagenet/multiedge_inference_bench/testalgorithms/automatic/models/transformers/bert.py
+++ b/examples/imagenet/multiedge_inference_bench/testalgorithms/automatic/models/transformers/bert.py
@@ -42,7 +42,7 @@ class BertLayerShard(ModuleShard):
     def forward(self, data: TransformerShardData) -> TransformerShardData:
         """Compute layer shard."""
         if self.has_layer(0):
-            data = (self.self_attention(data)[0], data)
+            data = (self.self_attention(data, attention_mask=None, past_key_values=None)[0], data)
         if self.has_layer(1):
             data = self.self_output(data[0], data[1])
         if self.has_layer(2):
@@ -104,10 +104,14 @@ class BertModelShard(ModuleShard):
     @torch.no_grad()
     def _load_weights_first(self, weights):
         self.embeddings.position_ids.copy_(torch.from_numpy((weights["embeddings.position_ids"])))
-        self.embeddings.word_embeddings.weight.copy_(torch.from_numpy(weights['embeddings.word_embeddings.weight']))
-        self.embeddings.position_embeddings.weight.copy_(torch.from_numpy(weights['embeddings.position_embeddings.weight']))
-        self.embeddings.token_type_embeddings.weight.copy_(torch.from_numpy(weights['embeddings.token_type_embeddings.weight']))
-        self.embeddings.LayerNorm.weight.copy_(torch.from_numpy(weights['embeddings.LayerNorm.weight']))
+        self.embeddings.word_embeddings.weight.copy_(
+            torch.from_numpy(weights['embeddings.word_embeddings.weight']))
+        self.embeddings.position_embeddings.weight.copy_(
+            torch.from_numpy(weights['embeddings.position_embeddings.weight']))
+        self.embeddings.token_type_embeddings.weight.copy_(
+            torch.from_numpy(weights['embeddings.token_type_embeddings.weight']))
+        self.embeddings.LayerNorm.weight.copy_(
+            torch.from_numpy(weights['embeddings.LayerNorm.weight']))
         self.embeddings.LayerNorm.bias.copy_(torch.from_numpy(weights['embeddings.LayerNorm.bias']))
 
     @torch.no_grad()
@@ -119,31 +123,48 @@ class BertModelShard(ModuleShard):
     def _load_weights_layer(self, weights, layer_id, layer):
         root = f"encoder.layer.{layer_id}."
         if layer.has_layer(0):
-            layer.self_attention.query.weight.copy_(torch.from_numpy(weights[root + "attention.self.query.weight"]))
-            layer.self_attention.key.weight.copy_(torch.from_numpy(weights[root + "attention.self.key.weight"]))
-            layer.self_attention.value.weight.copy_(torch.from_numpy(weights[root + "attention.self.value.weight"]))
-            layer.self_attention.query.bias.copy_(torch.from_numpy(weights[root + "attention.self.query.bias"]))
-            layer.self_attention.key.bias.copy_(torch.from_numpy(weights[root + "attention.self.key.bias"]))
-            layer.self_attention.value.bias.copy_(torch.from_numpy(weights[root + "attention.self.value.bias"]))
+            layer.self_attention.query.weight.copy_(
+                torch.from_numpy(weights[root + "attention.self.query.weight"]))
+            layer.self_attention.key.weight.copy_(
+                torch.from_numpy(weights[root + "attention.self.key.weight"]))
+            layer.self_attention.value.weight.copy_(
+                torch.from_numpy(weights[root + "attention.self.value.weight"]))
+            layer.self_attention.query.bias.copy_(
+                torch.from_numpy(weights[root + "attention.self.query.bias"]))
+            layer.self_attention.key.bias.copy_(
+                torch.from_numpy(weights[root + "attention.self.key.bias"]))
+            layer.self_attention.value.bias.copy_(
+                torch.from_numpy(weights[root + "attention.self.value.bias"]))
         if layer.has_layer(1):
-            layer.self_output.dense.weight.copy_(torch.from_numpy(weights[root + "attention.output.dense.weight"]))
-            layer.self_output.LayerNorm.weight.copy_(torch.from_numpy(weights[root + "attention.output.LayerNorm.weight"]))
-            layer.self_output.dense.bias.copy_(torch.from_numpy(weights[root + "attention.output.dense.bias"]))
-            layer.self_output.LayerNorm.bias.copy_(torch.from_numpy(weights[root + "attention.output.LayerNorm.bias"]))
+            layer.self_output.dense.weight.copy_(
+                torch.from_numpy(weights[root + "attention.output.dense.weight"]))
+            layer.self_output.LayerNorm.weight.copy_(
+                torch.from_numpy(weights[root + "attention.output.LayerNorm.weight"]))
+            layer.self_output.dense.bias.copy_(
+                torch.from_numpy(weights[root + "attention.output.dense.bias"]))
+            layer.self_output.LayerNorm.bias.copy_(
+                torch.from_numpy(weights[root + "attention.output.LayerNorm.bias"]))
         if layer.has_layer(2):
-            layer.intermediate.dense.weight.copy_(torch.from_numpy(weights[root + "intermediate.dense.weight"]))
-            layer.intermediate.dense.bias.copy_(torch.from_numpy(weights[root + "intermediate.dense.bias"]))
+            layer.intermediate.dense.weight.copy_(
+                torch.from_numpy(weights[root + "intermediate.dense.weight"]))
+            layer.intermediate.dense.bias.copy_(
+                torch.from_numpy(weights[root + "intermediate.dense.bias"]))
         if layer.has_layer(3):
             layer.output.dense.weight.copy_(torch.from_numpy(weights[root + "output.dense.weight"]))
             layer.output.dense.bias.copy_(torch.from_numpy(weights[root + "output.dense.bias"]))
-            layer.output.LayerNorm.weight.copy_(torch.from_numpy(weights[root + "output.LayerNorm.weight"]))
-            layer.output.LayerNorm.bias.copy_(torch.from_numpy(weights[root + "output.LayerNorm.bias"]))
+            layer.output.LayerNorm.weight.copy_(
+                torch.from_numpy(weights[root + "output.LayerNorm.weight"]))
+            layer.output.LayerNorm.bias.copy_(
+                torch.from_numpy(weights[root + "output.LayerNorm.bias"]))
 
     @torch.no_grad()
     def forward(self, data: TransformerShardData) -> TransformerShardData:
         """Compute shard layers."""
         if self.shard_config.is_first:
-            data = self.embeddings(data)
+            if isinstance(data, tuple):
+                data = self.embeddings(input_ids=data[0], token_type_ids=data[1])
+            else:
+                data = self.embeddings(input_ids=data)
         for layer in self.layers:
             data = layer(data)
         if self.shard_config.is_last:
@@ -157,7 +178,7 @@ class BertModelShard(ModuleShard):
         state_dict = model.state_dict()
         weights = {}
         for key, val in state_dict.items():
-            weights[key] = val
+            weights[key] = val.detach().cpu().numpy()
         np.savez(model_file, **weights)
 
 
@@ -215,5 +236,5 @@ class BertShardForSequenceClassification(ModuleShard):
         state_dict = model.state_dict()
         weights = {}
         for key, val in state_dict.items():
-            weights[key] = val
+            weights[key] = val.detach().cpu().numpy()
         np.savez(model_file, **weights)

--- a/examples/imagenet/multiedge_inference_bench/testalgorithms/automatic/models/transformers/deit.py
+++ b/examples/imagenet/multiedge_inference_bench/testalgorithms/automatic/models/transformers/deit.py
@@ -1,6 +1,7 @@
 """DeiT Transformers."""
 from collections.abc import Mapping
 import logging
+import warnings
 import math
 from typing import Optional, Union
 import numpy as np
@@ -56,7 +57,10 @@ class DeiTLayerShard(ModuleShard):
         """Compute layer shard."""
         if self.has_layer(0):
             data_norm = self.layernorm_before(data)
-            data = (self.self_attention(data_norm)[0], data)
+            data = (self.self_attention(
+                data_norm,
+                attention_mask=None,
+            )[0], data)
         if self.has_layer(1):
             skip = data[1]
             data = self.self_output(data[0], skip)
@@ -120,8 +124,10 @@ class DeiTModelShard(ModuleShard):
     def _load_weights_first(self, weights):
         self.embeddings.cls_token.copy_(torch.from_numpy(weights["cls_token"]))
         self.embeddings.position_embeddings.copy_(torch.from_numpy((weights["pos_embed"])))
-        self.embeddings.patch_embeddings.projection.weight.copy_(torch.from_numpy(weights["patch_embed.proj.weight"]))
-        self.embeddings.patch_embeddings.projection.bias.copy_(torch.from_numpy(weights["patch_embed.proj.bias"]))
+        self.embeddings.patch_embeddings.projection.weight.copy_(
+            torch.from_numpy(weights["patch_embed.proj.weight"]))
+        self.embeddings.patch_embeddings.projection.bias.copy_(
+            torch.from_numpy(weights["patch_embed.proj.bias"]))
 
     @torch.no_grad()
     def _load_weights_last(self, weights):
@@ -137,19 +143,24 @@ class DeiTModelShard(ModuleShard):
             layer.layernorm_before.bias.copy_(torch.from_numpy(weights[root + "norm1.bias"]))
             qkv_weight = weights[root + "attn.qkv.weight"]
             layer.self_attention.query.weight.copy_(torch.from_numpy(qkv_weight[0:embed_dim,:]))
-            layer.self_attention.key.weight.copy_(torch.from_numpy(qkv_weight[embed_dim:embed_dim*2,:]))
-            layer.self_attention.value.weight.copy_(torch.from_numpy(qkv_weight[embed_dim*2:embed_dim*3,:]))
+            layer.self_attention.key.weight.copy_(
+                torch.from_numpy(qkv_weight[embed_dim:embed_dim*2,:]))
+            layer.self_attention.value.weight.copy_(
+                torch.from_numpy(qkv_weight[embed_dim*2:embed_dim*3,:]))
             qkv_bias = weights[root + "attn.qkv.bias"]
             layer.self_attention.query.bias.copy_(torch.from_numpy(qkv_bias[0:embed_dim,]))
             layer.self_attention.key.bias.copy_(torch.from_numpy(qkv_bias[embed_dim:embed_dim*2]))
-            layer.self_attention.value.bias.copy_(torch.from_numpy(qkv_bias[embed_dim*2:embed_dim*3]))
+            layer.self_attention.value.bias.copy_(
+                torch.from_numpy(qkv_bias[embed_dim*2:embed_dim*3]))
         if layer.has_layer(1):
-            layer.self_output.dense.weight.copy_(torch.from_numpy(weights[root + "attn.proj.weight"]))
+            layer.self_output.dense.weight.copy_(
+                torch.from_numpy(weights[root + "attn.proj.weight"]))
             layer.self_output.dense.bias.copy_(torch.from_numpy(weights[root + "attn.proj.bias"]))
         if layer.has_layer(2):
             layer.layernorm_after.weight.copy_(torch.from_numpy(weights[root + "norm2.weight"]))
             layer.layernorm_after.bias.copy_(torch.from_numpy(weights[root + "norm2.bias"]))
-            layer.intermediate.dense.weight.copy_(torch.from_numpy(weights[root + "mlp.fc1.weight"]))
+            layer.intermediate.dense.weight.copy_(
+                torch.from_numpy(weights[root + "mlp.fc1.weight"]))
             layer.intermediate.dense.bias.copy_(torch.from_numpy(weights[root + "mlp.fc1.bias"]))
         if layer.has_layer(3):
             layer.output.dense.weight.copy_(torch.from_numpy(weights[root + "mlp.fc2.weight"]))
@@ -178,7 +189,7 @@ class DeiTModelShard(ModuleShard):
                              hub_model_name)
             else:
                 hub_model_name = model_name
-        import warnings
+
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", FutureWarning)
             model = torch.hub.load(hub_repo, hub_model_name, pretrained=True)
@@ -212,7 +223,10 @@ class DeiTShardForImageClassification(ModuleShard):
 
         if self.shard_config.is_last:
             logger.debug(">>>> Load classifier for the last shard")
-            self.classifier = nn.Linear(self.config.hidden_size, self.config.num_labels) if self.config.num_labels > 0 else nn.Identity()
+            self.classifier = (
+                nn.Linear(self.config.hidden_size, self.config.num_labels)
+                if self.config.num_labels > 0 else nn.Identity()
+            )
             self._load_weights_last(weights)
 
     @torch.no_grad()

--- a/examples/imagenet/multiedge_inference_bench/testalgorithms/automatic/models/transformers/vit.py
+++ b/examples/imagenet/multiedge_inference_bench/testalgorithms/automatic/models/transformers/vit.py
@@ -57,7 +57,10 @@ class ViTLayerShard(ModuleShard):
         """Compute layer shard."""
         if self.has_layer(0):
             data_norm = self.layernorm_before(data)
-            data = (self.self_attention(data_norm)[0], data)
+            data = (self.self_attention(
+                data_norm,
+                attention_mask=None,
+            )[0], data)
         if self.has_layer(1):
             skip = data[1]
             data = self.self_output(data[0], skip)

--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/benchmarkingjob.yaml
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/benchmarkingjob.yaml
@@ -2,11 +2,13 @@ benchmarkingjob:
   # job name of bechmarking; string type;
   name: "benchmarkingjob"
   # the url address of job workspace that will reserve the output of tests; string type;
-  workspace: "./ianvs-workspace/mdil-ss/lifelong_learning_bench"
+  workspace: "./ianvs-workspace/robot-cityscapes-synthia/lifelong_learning_bench"
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;
-  testenv: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testenv/testenv.yaml"
+  testenv: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testenv/testenv.yaml"
+
+
 
   # the configuration of test object
   test_object:
@@ -19,7 +21,7 @@ benchmarkingjob:
       - name: "erfnet_lifelong_learning"
         # the url address of test algorithm configuration file; string type;
         # the file format supports yaml/yml
-        url: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testalgorithms/erfnet/test_algorithm.yaml"
+        url: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/test_algorithm.yaml"
 
   # the configuration of ranking leaderboard
   rank:

--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/dataloaders/datasets/cityscapes.py
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/dataloaders/datasets/cityscapes.py
@@ -1,5 +1,5 @@
 import os
-os.environ["OMP_NUM_THREADS"] = "1" 
+os.environ["OMP_NUM_THREADS"] = "1"
 os.environ["MKL_NUM_THREADS"] = "1"
 import numpy as np
 from PIL import Image
@@ -21,31 +21,55 @@ class CityscapesSegmentation(data.Dataset):
         self.labels = {}
 
         self.disparities_base = os.path.join(self.root, self.split, "depth", "cityscapes_real")
-        self.images[split] = [img[0] for img in data.x] if hasattr(data, "x") else data
 
+        if data is None:
+            raise ValueError(
+                f"CityscapesSegmentation requires a 'data' argument for split='{split}', but received None. "
+                "Ensure the dataset is correctly passed from the Ianvs/Sedna pipeline."
+            )
 
-        if hasattr(data, "x") and len(data.x[0]) == 1:
-            # TODO: fit the case that depth images don't exist.
-            self.disparities[split] = self.images[split]
-        elif hasattr(data, "x") and len(data.x[0]) == 2:
-            self.disparities[split] = [img[1] for img in data.x]
-        else:
-            if len(data[0]) == 2:
-                self.images[split] = [img[0] for img in data]
-                self.disparities[split] = [img[1] for img in data]
-            elif len(data[0]) == 1:
-                self.images[split] = [img[0] for img in data]
-                self.disparities[split] = [img[0] for img in data]
+        # Handle BaseDataSource (has .x and .y attributes)
+        if hasattr(data, "x"):
+            raw_x = data.x
+            if not raw_x:
+                raise ValueError(f"data.x is empty for split='{split}'.")
+
+            self.images[split] = [img[0] for img in raw_x]
+
+            if len(raw_x[0]) == 1:
+                # Only RGB, no depth — reuse RGB as depth placeholder
+                self.disparities[split] = self.images[split]
+            elif len(raw_x[0]) >= 2:
+                self.disparities[split] = [img[1] for img in raw_x]
             else:
-                self.images[split] = data
-                self.disparities[split] = data
+                self.disparities[split] = self.images[split]
 
-        self.labels[split] = data.y if hasattr(data, "y") else data
+            # data.y may be None during inference; handle gracefully
+            self.labels[split] = list(data.y) if (hasattr(data, "y") and data.y is not None) else None
+
+        # Handle plain list/tuple of paths
+        else:
+            raw = list(data)
+            if not raw:
+                raise ValueError(f"data is empty for split='{split}'.")
+
+            if isinstance(raw[0], (list, tuple)):
+                if len(raw[0]) >= 2:
+                    self.images[split] = [img[0] for img in raw]
+                    self.disparities[split] = [img[1] for img in raw]
+                else:
+                    self.images[split] = [img[0] for img in raw]
+                    self.disparities[split] = [img[0] for img in raw]
+            else:
+                self.images[split] = raw
+                self.disparities[split] = raw
+
+            self.labels[split] = None
 
         self.ignore_index = 255
 
         if len(self.images[split]) == 0:
-            raise Exception("No RGB images for split=[%s] found in %s" % (split, self.images_base))
+            raise Exception("No RGB images for split=[%s] found in %s" % (split, self.root))
         if len(self.disparities[split]) == 0:
             raise Exception("No depth images for split=[%s] found in %s" % (split, self.disparities_base))
 
@@ -60,15 +84,21 @@ class CityscapesSegmentation(data.Dataset):
         img_path = self.images[self.split][index].rstrip()
         disp_path = self.disparities[self.split][index].rstrip()
         try:
-            lbl_path = self.labels[self.split][index].rstrip()
+            labels = self.labels[self.split]
+            if labels is not None:
+                lbl_path = labels[index].rstrip()
+                _img = Image.open(img_path).convert('RGB')
+                _depth = Image.open(disp_path)
+                _target = Image.open(lbl_path)
+                sample = {'image': _img, 'depth': _depth, 'label': _target}
+            else:
+                _img = Image.open(img_path).convert('RGB')
+                _depth = Image.open(disp_path)
+                sample = {'image': _img, 'depth': _depth, 'label': _img}
+        except Exception:
             _img = Image.open(img_path).convert('RGB')
             _depth = Image.open(disp_path)
-            _target = Image.open(lbl_path)
-            sample = {'image': _img,'depth':_depth, 'label': _target}
-        except:
-            _img = Image.open(img_path).convert('RGB')
-            _depth = Image.open(disp_path)
-            sample = {'image': _img,'depth':_depth, 'label': _img}
+            sample = {'image': _img, 'depth': _depth, 'label': _img}
 
         if self.split == 'train':
             return self.transform_tr(sample)
@@ -153,4 +183,3 @@ if __name__ == '__main__':
             break
 
     plt.show(block=True)
-

--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/sedna_evaluate.py
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/sedna_evaluate.py
@@ -20,9 +20,9 @@ def eval():
     eval_data.parse(eval_dataset_url, use_raw=False)
 
     task_allocation = {
-        "method": "TaskAllocationByOrigin",
+        "method": "TaskAllocationByDomain",
         "param": {
-            "origins": ["real", "sim"]
+            "origins": ["Cityscapes", "Synthia", "Cloud-Robotics"]
         }
     }
 

--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/sedna_train.py
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/sedna_train.py
@@ -20,16 +20,16 @@ def _load_txt_dataset(dataset_url):
 
 def train(estimator, train_data):
     task_definition = {
-        "method": "TaskDefinitionByOrigin",
+        "method": "TaskDefinitionByDomain",
         "param": {
-            "origins": ["real", "sim"]
+            "origins": ["Cityscapes", "Synthia", "Cloud-Robotics"]
         }
     }
 
     task_allocation = {
-        "method": "TaskAllocationByOrigin",
+        "method": "TaskAllocationByDomain",
         "param": {
-            "origins": ["real", "sim"]
+            "origins": ["Cityscapes", "Synthia", "Cloud-Robotics"]
         }
     }
 

--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/task_allocation_by_domain.py
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/task_allocation_by_domain.py
@@ -18,13 +18,15 @@ class TaskAllocationByOrigin:
         label with finite values.
     """
 
-    def __init__(self, **kwargs):
+    def __init__(self, task_extractor=None, **kwargs):
         self.default_origin = kwargs.get("default", None)
+        # Sedna passes task_extractor to __init__, not __call__.
+        # Store it here; fall back to a hardcoded mapping if not provided.
+        self.task_extractor = task_extractor if task_extractor is not None else {
+            "Synthia": 0, "Cityscapes": 1, "Cloud-Robotics": 2
+        }
 
-    def __call__(self, task_extractor, samples: BaseDataSource):
-        # Mapping of origins to task indices
-        self.task_extractor = {"Synthia": 0, "Cityscapes": 1, "Cloud-Robotics": 2}
-
+    def __call__(self, samples: BaseDataSource):
         if self.default_origin:
             return samples, [int(self.task_extractor.get(self.default_origin))] * len(samples.x)
 
@@ -39,7 +41,6 @@ class TaskAllocationByOrigin:
                     sample_origin = category
                     break
             if sample_origin is None:
-                # If none of the categories match, assign a default origin
                 sample_origin = self.default_origin if self.default_origin else categories[0]
             sample_origins.append(sample_origin)
 

--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/test_algorithm.yaml
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/test_algorithm.yaml
@@ -25,7 +25,7 @@ algorithm:
       # example: basemodel.py has BaseModel module that the alias is "FPN" for this benchmarking;
       name: "BaseModel"
       # the url address of python module; string type;
-      url: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testalgorithms/erfnet/basemodel.py"
+      url: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/ERFNet/basemodel.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -40,7 +40,7 @@ algorithm:
       # name of python module; string type;
       name: "TaskDefinitionByDomain"
       # the url address of python module; string type;
-      url: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testalgorithms/erfnet/task_definition_by_domain.py"
+      url: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/task_definition_by_domain.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;
@@ -53,7 +53,7 @@ algorithm:
       # name of python module; string type;
       name: "TaskAllocationByDomain"
       # the url address of python module; string type;
-      url: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testalgorithms/erfnet/task_allocation_by_domain.py"
+      url: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testalgorithms/erfnet/task_allocation_by_domain.py"
       # hyperparameters configuration for the python module; list type;
       hyperparameters:
         # name of the hyperparameter; string type;

--- a/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testenv/testenv.yaml
+++ b/examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testenv/testenv.yaml
@@ -2,9 +2,10 @@ testenv:
   # dataset configuration
   dataset:
     # the url address of train dataset index; string type;
-    train_url: "/home/QXY/dataset/mdil-ss/train/mdil-ss-train-index-small.txt"
+    train_url: "./dataset/robot-cityscapes-synthia/left/left_train.txt"
+
     # the url address of test dataset index; string type;
-    test_url: "/home/QXY/dataset/mdil-ss/test/mdil-ss-test-index-small.txt"
+    test_url: "./dataset/robot-cityscapes-synthia/left/left_val.txt"
 
   # model eval configuration of incremental learning;
   model_eval:
@@ -13,7 +14,7 @@ testenv:
       # metric name; string type;
       name: "accuracy"
       # the url address of python file
-      url: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testenv/accuracy.py"
+      url: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testenv/accuracy.py"
       mode: "no-inference"
 
     # condition of triggering inference model to update
@@ -28,7 +29,7 @@ testenv:
       # metric name; string type;
     - name: "accuracy"
       # the url address of python file
-      url: "./examples/class_increment_semantic_segmentation/lifelong_learning_bench/testenv/accuracy.py"
+      url: "./examples/robot-cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/testenv/accuracy.py"
     - name: "samples_transfer_ratio"
     - name: "task_avg_acc"
     - name: "BWT"


### PR DESCRIPTION
## Summary

This PR consolidates multiple bug fixes for the `multiedge-inference-bench` examples 
into a single pull request as requested in the community meeting.

Closes #503, #506, #507, #508

## Changes

### MOT17/multiedge_inference_bench
- Fix missing DDP/dist imports, assertion error, and YAML in ByteTrack
- Resolve issues #447, #449, #450

### robot-cityscapes-synthia
- Fix stale 2-domain config updated to 3-domain in scripts
- Fix incorrect basemodel.py URL to include ERFNet subdirectory
- Fix stale paths and hardcoded absolute paths in benchmarkingjob.yaml and testenv.yaml
- Fix missing semantic-segmentation directory level in testenv path
- Fix three Sedna interface crashes in task_allocation and cityscapes dataset

## Issues Fixed
- Resolves #447
- Resolves #449
- Resolves #450
- Resolves #514