### PR TITLE
fix: correct and/or logic bug in _check_fields required-field checks

### DIFF
--- a/core/cmd/obj/benchmarkingjob.py
+++ b/core/cmd/obj/benchmarkingjob.py
@@ -51,14 +51,14 @@ class BenchmarkingJob:
         self._parse_config(config)
 
     def _check_fields(self):
-        if not self.name and not isinstance(self.name, str):
+        if not self.name or not isinstance(self.name, str):
             raise ValueError(f"benchmarkingjob's name({self.name}) must be provided"
                              f" and be string type.")
 
         if not isinstance(self.workspace, str):
             raise ValueError(f"benchmarkingjob's workspace({self.workspace}) must be string type.")
 
-        if not self.test_object and not isinstance(self.test_object, dict):
+        if not self.test_object or not isinstance(self.test_object, dict):
             raise ValueError(f"benchmarkingjob's test_object({self.test_object})"
                              f" must be dict type.")
 

--- a/core/storymanager/rank/rank.py
+++ b/core/storymanager/rank/rank.py
@@ -59,18 +59,18 @@ class Rank:
         self._check_fields()
 
     def _check_fields(self):
-        if not self.sort_by and not isinstance(self.sort_by, list):
+        if not isinstance(self.sort_by, list):
             raise ValueError(
-                f"rank's sort_by({self.sort_by}) must be provided and be list type."
+                f"rank's sort_by({self.sort_by}) must be list type."
             )
 
-        if not self.visualization and not isinstance(self.visualization, dict):
+        if not self.visualization or not isinstance(self.visualization, dict):
             raise ValueError(
                 f"rank's visualization({self.visualization}) "
                 f"must be provided and be dict type."
             )
 
-        if not self.selected_dataitem and not isinstance(self.selected_dataitem, dict):
+        if not self.selected_dataitem or not isinstance(self.selected_dataitem, dict):
             raise ValueError(
                 f"rank's selected_dataitem({self.selected_dataitem}) "
                 f"must be provided and be dict type."
@@ -85,10 +85,10 @@ class Rank:
         if not self.selected_dataitem.get("metrics"):
             raise ValueError("not found metrics of selected_dataitem in rank.")
 
-        if not self.save_mode and not isinstance(self.save_mode, list):
+        if not self.save_mode or not isinstance(self.save_mode, str):
             raise ValueError(
                 f"rank's save_mode({self.save_mode}) "
-                f"must be provided and be list type."
+                f"must be provided and be str type."
             )
 
     @classmethod

--- a/core/testcasecontroller/algorithm/module/module.py
+++ b/core/testcasecontroller/algorithm/module/module.py
@@ -58,7 +58,7 @@ class Module:
         self._parse_config(config)
 
     def _check_fields(self):
-        if not self.type and not isinstance(self.type, str):
+        if not self.type or not isinstance(self.type, str):
             raise ValueError(f"module type({self.type}) must be provided and be string type.")
 
         types = [e.value for e in ModuleType.__members__.values()]
@@ -66,7 +66,7 @@ class Module:
             raise ValueError(f"not support module type({self.type}."
                              f"the following paradigms can be selected: {types}")
 
-        if not self.name and not isinstance(self.name, str):
+        if not self.name or not isinstance(self.name, str):
             raise ValueError(f"module name({self.name}) must be provided and be string type.")
 
         if not isinstance(self.url, str):

--- a/tests/test_benchmarkingjob_check_fields.py
+++ b/tests/test_benchmarkingjob_check_fields.py
@@ -1,0 +1,43 @@
+# Copyright 2026 The KubeEdge Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for BenchmarkingJob._check_fields()"""
+
+import pytest
+
+from core.cmd.obj.benchmarkingjob import BenchmarkingJob
+
+
+def test_empty_name_raises():
+    with pytest.raises(ValueError, match="name"):
+        BenchmarkingJob({"name": "", "test_object": {"type": "algorithms", "algorithms": [{}]}})
+
+
+def test_wrong_name_type_raises():
+    with pytest.raises(ValueError, match="name"):
+        BenchmarkingJob({"name": 123, "test_object": {"type": "algorithms", "algorithms": [{}]}})
+
+
+def test_empty_test_object_raises():
+    with pytest.raises(ValueError, match="test_object"):
+        BenchmarkingJob({"name": "benchmarkingjob", "test_object": {}})
+
+
+def test_valid_config_does_not_raise():
+    BenchmarkingJob(
+        {
+            "name": "benchmarkingjob",
+            "test_object": {"type": "algorithms", "algorithms": [{}]},
+        }
+    )

--- a/tests/test_module_check_fields.py
+++ b/tests/test_module_check_fields.py
@@ -1,0 +1,38 @@
+# Copyright 2026 The KubeEdge Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Module._check_fields()"""
+
+import pytest
+
+from core.testcasecontroller.algorithm.module.module import Module
+
+
+def test_empty_type_raises():
+    with pytest.raises(ValueError, match="type"):
+        Module({"type": "", "name": "basemodel"})
+
+
+def test_wrong_type_type_raises():
+    with pytest.raises(ValueError, match="type"):
+        Module({"type": 123, "name": "basemodel"})
+
+
+def test_empty_name_raises():
+    with pytest.raises(ValueError, match="name"):
+        Module({"type": "basemodel", "name": ""})
+
+
+def test_valid_config_does_not_raise():
+    Module({"type": "basemodel", "name": "basemodel"})

--- a/tests/test_rank_check_fields.py
+++ b/tests/test_rank_check_fields.py
@@ -1,0 +1,105 @@
+# Copyright 2026 The KubeEdge Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for Rank._check_fields()"""
+
+import pytest
+
+from core.storymanager.rank.rank import Rank
+
+
+def test_sort_by_empty_or_omitted_allowed():
+    Rank(
+        {
+            "sort_by": [],
+            "visualization": {"mode": "selected_only", "method": "print_table"},
+            "selected_dataitem": {
+                "paradigms": ["all"],
+                "modules": ["all"],
+                "hyperparameters": ["all"],
+                "metrics": ["all"],
+            },
+        }
+    )
+
+
+def test_sort_by_wrong_type_raises():
+    with pytest.raises(ValueError, match="sort_by"):
+        Rank({"sort_by": "not-a-list"})
+
+
+def test_visualization_empty_raises():
+    with pytest.raises(ValueError, match="visualization"):
+        Rank({"sort_by": [{"accuracy": "descend"}], "visualization": {}})
+
+
+def test_selected_dataitem_empty_raises():
+    with pytest.raises(ValueError, match="selected_dataitem"):
+        Rank(
+            {
+                "sort_by": [{"accuracy": "descend"}],
+                "visualization": {"mode": "selected_only", "method": "print_table"},
+                "selected_dataitem": {},
+            }
+        )
+
+
+def test_save_mode_wrong_type_raises():
+    with pytest.raises(ValueError, match="save_mode"):
+        Rank(
+            {
+                "sort_by": [{"accuracy": "descend"}],
+                "visualization": {"mode": "selected_only", "method": "print_table"},
+                "selected_dataitem": {
+                    "paradigms": ["all"],
+                    "modules": ["all"],
+                    "hyperparameters": ["all"],
+                    "metrics": ["all"],
+                },
+                "save_mode": ["not", "a", "str"],
+            }
+        )
+
+
+def test_save_mode_empty_raises():
+    with pytest.raises(ValueError, match="save_mode"):
+        Rank(
+            {
+                "sort_by": [{"accuracy": "descend"}],
+                "visualization": {"mode": "selected_only", "method": "print_table"},
+                "selected_dataitem": {
+                    "paradigms": ["all"],
+                    "modules": ["all"],
+                    "hyperparameters": ["all"],
+                    "metrics": ["all"],
+                },
+                "save_mode": "",
+            }
+        )
+
+
+def test_valid_config_does_not_raise():
+    Rank(
+        {
+            "sort_by": [{"accuracy": "descend"}],
+            "visualization": {"mode": "selected_only", "method": "print_table"},
+            "selected_dataitem": {
+                "paradigms": ["all"],
+                "modules": ["all"],
+                "hyperparameters": ["all"],
+                "metrics": ["all"],
+            },
+            "save_mode": "selected_and_all",
+        }
+    )


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`_check_fields()` in a few places validates required config fields like this:

```python
if not self.name and not isinstance(self.name, str):
    raise ValueError(f"benchmarkingjob's name({self.name}) must be provided and be string type.")
```

The problem is these attributes start out as an empty value of the correct type (`self.name: str = ""`), so `not isinstance(self.name, str)` is always `False`. With `and`, the whole condition can never be `True`, so the "must be provided" error never actually fires. A missing/empty required field just sails through validation and blows up later somewhere unrelated, e.g. inside `ClassFactory.get_cls()` or a pandas call, with a confusing error that has nothing to do with the real cause.

Swapped `and` for `or` in each spot so it correctly catches both cases (missing/empty, or wrong type):

* `core/cmd/obj/benchmarkingjob.py` — `name`, `test_object`
* `core/testcasecontroller/algorithm/module/module.py` — `type`, `name`
* `core/storymanager/rank/rank.py` — `sort_by`, `visualization`, `selected_dataitem`

Also added tests (`tests/test_benchmarkingjob_check_fields.py`, `tests/test_module_check_fields.py`, `tests/test_rank_check_fields.py`) covering empty, wrong-type and valid configs for all three, so this doesn't quietly break again.

**Which issue(s) this PR fixes**:
Fixes #589