### PR TITLE
fix: avoid ZeroDivisionError in city_splitting when times=1

### DIFF
--- a/core/testenvmanager/dataset/dataset.py
+++ b/core/testenvmanager/dataset/dataset.py
@@ -441,6 +441,8 @@ class Dataset:
             )
         )
         times = times - 1
+        if times <= 0:
+            return data_files
         step = int((len(all_data) - index0) / times)
         index = 1
         while index <= times:


### PR DESCRIPTION
/kind bug

## What this PR does

Fixes a `ZeroDivisionError` in `Dataset._city_splitting()` (`core/testenvmanager/dataset/dataset.py`) that is raised whenever the method is called with `times=1`.

## Why we need it

`_city_splitting()` always emits one initial split up front (the `synthia_sim`-prefixed chunk), then does:

```python
times = times - 1
step = int((len(all_data) - index0) / times)
```

`times=1` is the default value of the `times` parameter throughout `split_dataset()`, and it is also the default of `incremental_rounds` in the lifelong learning paradigm (`self.incremental_rounds = kwargs.get("incremental_rounds", 1)`). So with `times=1`, the line above becomes `times = 0`, and the very next line divides by it.

`splitting_method: "city_splitting"` is a supported, documented option (used by `examples/cityscapes-synthia/lifelong_learning_bench/semantic-segmentation`). That example currently avoids the crash only because its `testenv*.yaml` files happen to set `incremental_rounds: 2` or `3` explicitly — anyone who sets `incremental_rounds: 1`, or omits it and relies on the framework default, hits the crash during dataset preparation, before any training or inference runs.

The sibling splitting methods in the same file (`_splitting_more_times`, `_fwt_splitting`, `_hard_example_splitting`) divide by `times` directly and never decrement it, so they don't have this issue.

## Changes

Return the single initial split early once `times` (after decrementing) reaches zero, instead of falling through to a division by zero:

```python
times = times - 1
if times <= 0:
    return data_files
step = int((len(all_data) - index0) / times)
```

Verified locally with a minimal dataset: `split_dataset(..., method="city_splitting", times=1)` now returns the single split instead of raising, and `times>=2` still produces the same output as before.

## Which issue(s) this PR fixes

Fixes #591