### PR TITLE
fix: correct field type validation logic in core modules

### DIFF
--- a/core/cmd/obj/benchmarkingjob.py
+++ b/core/cmd/obj/benchmarkingjob.py
@@ -51,14 +51,14 @@ class BenchmarkingJob:
         self._parse_config(config)
 
     def _check_fields(self):
-        if not self.name and not isinstance(self.name, str):
+        if not self.name or not isinstance(self.name, str):
             raise ValueError(f"benchmarkingjob's name({self.name}) must be provided"
                              f" and be string type.")
 
         if not isinstance(self.workspace, str):
             raise ValueError(f"benchmarkingjob's workspace({self.workspace}) must be string type.")
 
-        if not self.test_object and not isinstance(self.test_object, dict):
+        if not self.test_object or not isinstance(self.test_object, dict):
             raise ValueError(f"benchmarkingjob's test_object({self.test_object})"
                              f" must be dict type.")
 

--- a/core/storymanager/rank/rank.py
+++ b/core/storymanager/rank/rank.py
@@ -59,18 +59,18 @@ class Rank:
         self._check_fields()
 
     def _check_fields(self):
-        if not self.sort_by and not isinstance(self.sort_by, list):
+        if not self.sort_by or not isinstance(self.sort_by, list):
             raise ValueError(
                 f"rank's sort_by({self.sort_by}) must be provided and be list type."
             )
 
-        if not self.visualization and not isinstance(self.visualization, dict):
+        if not self.visualization or not isinstance(self.visualization, dict):
             raise ValueError(
                 f"rank's visualization({self.visualization}) "
                 f"must be provided and be dict type."
             )
 
-        if not self.selected_dataitem and not isinstance(self.selected_dataitem, dict):
+        if not self.selected_dataitem or not isinstance(self.selected_dataitem, dict):
             raise ValueError(
                 f"rank's selected_dataitem({self.selected_dataitem}) "
                 f"must be provided and be dict type."
@@ -85,10 +85,10 @@ class Rank:
         if not self.selected_dataitem.get("metrics"):
             raise ValueError("not found metrics of selected_dataitem in rank.")
 
-        if not self.save_mode and not isinstance(self.save_mode, list):
+        if not self.save_mode or not isinstance(self.save_mode, str):
             raise ValueError(
                 f"rank's save_mode({self.save_mode}) "
-                f"must be provided and be list type."
+                f"must be provided and be string type."
             )
 
     @classmethod

--- a/core/testcasecontroller/algorithm/algorithm.py
+++ b/core/testcasecontroller/algorithm/algorithm.py
@@ -130,10 +130,10 @@ class Algorithm:
         return None
 
     def _check_fields(self):
-        if not self.name and not isinstance(self.name, str):
+        if not self.name or not isinstance(self.name, str):
             raise ValueError(f"algorithm name({self.name}) must be provided and be string type.")
 
-        if not self.paradigm_type and not isinstance(self.paradigm_type, str):
+        if not self.paradigm_type or not isinstance(self.paradigm_type, str):
             raise ValueError(
                 f"algorithm paradigm({self.paradigm_type}) must be provided and be string type.")
 

--- a/core/testcasecontroller/algorithm/module/module.py
+++ b/core/testcasecontroller/algorithm/module/module.py
@@ -58,7 +58,7 @@ class Module:
         self._parse_config(config)
 
     def _check_fields(self):
-        if not self.type and not isinstance(self.type, str):
+        if not self.type or not isinstance(self.type, str):
             raise ValueError(f"module type({self.type}) must be provided and be string type.")
 
         types = [e.value for e in ModuleType.__members__.values()]
@@ -66,7 +66,7 @@ class Module:
             raise ValueError(f"not support module type({self.type}."
                              f"the following paradigms can be selected: {types}")
 
-        if not self.name and not isinstance(self.name, str):
+        if not self.name or not isinstance(self.name, str):
             raise ValueError(f"module name({self.name}) must be provided and be string type.")
 
         if not isinstance(self.url, str):

--- a/tests/test_check_fields.py
+++ b/tests/test_check_fields.py
@@ -1,0 +1,79 @@
+# Copyright 2024 The KubeEdge Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+from core.storymanager.rank import Rank
+from core.cmd.obj.benchmarkingjob import BenchmarkingJob
+from core.testcasecontroller.algorithm.algorithm import Algorithm
+from core.testcasecontroller.algorithm.module import Module
+
+
+def test_rank_check_fields_invalid_types():
+    valid_sort_by = [{"acc": "ascend"}]
+    valid_vis = {"mode": "selected_only", "method": "print_table"}
+
+    # Test sort_by invalid type (string instead of list)
+    with pytest.raises(ValueError, match="sort_by"):
+        Rank({"sort_by": "accuracy"})
+
+    # Test visualization invalid type (list instead of dict)
+    with pytest.raises(ValueError, match="visualization"):
+        Rank({"sort_by": valid_sort_by, "visualization": ["invalid"]})
+
+    # Test selected_dataitem invalid type (list instead of dict)
+    with pytest.raises(ValueError, match="selected_dataitem"):
+        Rank({"sort_by": valid_sort_by, "visualization": valid_vis, "selected_dataitem": "invalid"})
+
+    # Test save_mode invalid type (list instead of string)
+    with pytest.raises(ValueError, match="save_mode"):
+        Rank({
+            "sort_by": valid_sort_by,
+            "visualization": valid_vis,
+            "selected_dataitem": {
+                "paradigms": ["all"],
+                "modules": ["all"],
+                "metrics": ["all"]
+            },
+            "save_mode": ["invalid"]
+        })
+
+
+def test_benchmarkingjob_check_fields_invalid_types():
+    # Test name invalid type (int instead of string)
+    with pytest.raises(ValueError, match="name"):
+        BenchmarkingJob({"name": 123})
+
+    # Test test_object invalid type (string instead of dict)
+    with pytest.raises(ValueError, match="test_object"):
+        BenchmarkingJob({"name": "test_job", "test_object": "invalid"})
+
+
+def test_algorithm_check_fields_invalid_types():
+    # Test name invalid type (int instead of string)
+    with pytest.raises(ValueError, match="name"):
+        Algorithm(123, {"algorithm": {"name": 123, "paradigm_type": "singletasklearning"}})
+
+    # Test paradigm_type invalid type (int instead of string)
+    with pytest.raises(ValueError, match="paradigm"):
+        Algorithm("test_alg", {"algorithm": {"name": "test_alg", "paradigm_type": 123}})
+
+
+def test_module_check_fields_invalid_types():
+    # Test module type invalid type (int instead of string)
+    with pytest.raises(ValueError, match="module type"):
+        Module({"type": 123, "name": "test_mod"})
+
+    # Test module name invalid type (int instead of string)
+    with pytest.raises(ValueError, match="module name"):
+        Module({"type": "basemodel", "name": 123})


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes a bug in configuration field validation (`_check_fields()`) across core components (`Rank`, `BenchmarkingJob`, `Algorithm`, and `Module`). 

When instantiating configuration parser objects, invalid non-empty data types (such as passing a `str` for `sort_by` or an `int` for `name`) were bypassing validation checks without raising a `ValueError`.

In `_check_fields()`, validation conditions were written using boolean `and` instead of `or` between presence and type checks:

```python
if not self.sort_by and not isinstance(self.sort_by, list):
    raise ValueError(...)
```

When an invalid non-empty data type was provided (e.g., `sort_by = "accuracy"`):
1. `not self.sort_by` evaluated to `False` because non-empty strings are truthy in Python.
2. `not isinstance(self.sort_by, list)` evaluated to `True`.
3. `False and True` resolved to `False`, bypassing the `ValueError` check.

As a result, invalid types silently passed initialization and caused obscure downstream runtime errors (such as `AttributeError` or `TypeError`) during pipeline execution.

Additionally, in `Rank._check_fields()`, `save_mode` was checked against `list` instead of `str` (`self.save_mode` is a string such as `"selected_and_all"` or `"selected_only"`).

Changes Introduced:
1. **Logical Operator Fix in Core Components**:
   Replaced boolean `and` with `or` in `_check_fields()` across:
   - `core/storymanager/rank/rank.py`
   - `core/cmd/obj/benchmarkingjob.py`
   - `core/testcasecontroller/algorithm/algorithm.py`
   - `core/testcasecontroller/algorithm/module/module.py`
2. **Save Mode Type Validation**:
   Corrected `Rank._check_fields()` to check `isinstance(self.save_mode, str)` with an updated error message.
3. **Unit Tests**:
   Added `tests/test_check_fields.py` to test field validation against invalid data types for `Rank`, `BenchmarkingJob`, `Algorithm`, and `Module`.

**Which issue(s) this PR fixes**:

Fixes #595

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
Fix configuration field validation in core components to properly raise ValueError on invalid input types.
```
