### PR TITLE
core: fix benchmark execution resiliency, result persistence, and module state pollution

### DIFF
--- a/core/common/utils.py
+++ b/core/common/utils.py
@@ -15,6 +15,7 @@
 """This script contains some common tools."""
 
 import importlib
+import importlib.util
 import os
 import sys
 import time
@@ -61,19 +62,23 @@ def get_local_time():
 def py2dict(url):
     """Convert py file to the dict."""
     if url.endswith('.py'):
+        if not os.path.isfile(url):
+            raise RuntimeError(f"config file({url}) does not exist")
         module_name = os.path.basename(url)[:-3]
-        config_dir = os.path.dirname(url)
-        sys.path.insert(0, config_dir)
-        mod = import_module(module_name)
-        sys.path.pop(0)
-        raw_dict = {
-            name: value
-            for name, value in mod.__dict__.items()
-            if not name.startswith('__')
-        }
-        sys.modules.pop(module_name)
-
-        return raw_dict
+        try:
+            spec = importlib.util.spec_from_file_location(module_name, url)
+            if spec is None or spec.loader is None:
+                raise RuntimeError(f"load spec failed for {url}")
+            mod = importlib.util.module_from_spec(spec)
+            spec.loader.exec_module(mod)
+            raw_dict = {
+                name: value
+                for name, value in mod.__dict__.items()
+                if not name.startswith('__')
+            }
+            return raw_dict
+        except Exception as err:
+            raise RuntimeError(f"convert py file({url}) to dict failed, error: {err}") from err
 
     raise RuntimeError('config file must be the py format')
 
@@ -95,9 +100,26 @@ def load_module(url):
     if os.path.isfile(url):
         module_name = module_name.split(".")[0]
 
-    sys.path.insert(0, module_path)
     try:
-        importlib.import_module(module_name)
-        sys.path.pop(0)
+        if os.path.isfile(url):
+            abs_url = os.path.abspath(url)
+            cached_mod = sys.modules.get(module_name)
+            if cached_mod is not None and getattr(cached_mod, "__file__", None) == abs_url:
+                return cached_mod
+
+            spec = importlib.util.spec_from_file_location(module_name, abs_url)
+            if spec is not None and spec.loader is not None:
+                mod = importlib.util.module_from_spec(spec)
+                sys.modules[module_name] = mod
+                spec.loader.exec_module(mod)
+                return mod
+
+        sys.path.insert(0, module_path)
+        try:
+            mod = import_module(module_name)
+            return mod
+        finally:
+            if module_path in sys.path:
+                sys.path.remove(module_path)
     except Exception as err:
         raise RuntimeError(f"load module(url={url}) failed, error: {err}") from err

--- a/core/storymanager/rank/rank.py
+++ b/core/storymanager/rank/rank.py
@@ -85,10 +85,10 @@ class Rank:
         if not self.selected_dataitem.get("metrics"):
             raise ValueError("not found metrics of selected_dataitem in rank.")
 
-        if not self.save_mode and not isinstance(self.save_mode, list):
+        if not self.save_mode and not isinstance(self.save_mode, (str, list)):
             raise ValueError(
                 f"rank's save_mode({self.save_mode}) "
-                f"must be provided and be list type."
+                f"must be provided and be str or list type."
             )
 
     @classmethod
@@ -236,8 +236,9 @@ class Rank:
             out_put = test_case.output_dir
             test_result = test_results[test_case.id][0]
             matrix = test_result.get("Matrix")
-            for key in matrix.keys():
-                draw_heatmap_picture(out_put, key, matrix[key])
+            if isinstance(matrix, dict):
+                for key in matrix.keys():
+                    draw_heatmap_picture(out_put, key, matrix[key])
 
     def _prepare(self, test_cases, test_results, output_dir):
         all_metric_names = self._get_all_metric_names(test_results)

--- a/core/testcasecontroller/testcase/testcase.py
+++ b/core/testcasecontroller/testcase/testcase.py
@@ -43,12 +43,12 @@ class TestCase:
         self.output_dir = None
 
     def _get_output_dir(self, workspace):
-        output_dir = os.path.join(workspace, self.algorithm.name)
-        flag = True
-        while flag:
-            output_dir = os.path.join(workspace, self.algorithm.name, str(self.id))
-            if not os.path.exists(output_dir):
-                flag = False
+        base_dir = os.path.join(workspace, self.algorithm.name)
+        output_dir = os.path.join(base_dir, str(self.id))
+        counter = 1
+        while os.path.exists(output_dir):
+            output_dir = os.path.join(base_dir, f"{self.id}_{counter}")
+            counter += 1
         return output_dir
 
     def run(self, workspace):

--- a/core/testcasecontroller/testcasecontroller.py
+++ b/core/testcasecontroller/testcasecontroller.py
@@ -16,6 +16,7 @@
 
 import copy
 
+from core.common.log import LOGGER
 from core.common import utils
 from core.common.constant import TestObjectType
 from core.testcasecontroller.algorithm import Algorithm
@@ -49,16 +50,39 @@ class TestCaseController:
         """
         succeed_results = {}
         succeed_testcases = []
+        failed_errors = []
+
         for testcase in self.test_cases:
             try:
                 res, time = (testcase.run(workspace), utils.get_local_time())
+                succeed_results[testcase.id] = (res, time)
+                succeed_testcases.append(testcase)
             except Exception as err:
-                raise RuntimeError(f"testcase(id={testcase.id}) runs failed, error: {err}") from err
+                msg = f"testcase(id={testcase.id}) runs failed, error: {err}"
+                LOGGER.error(msg)
+                failed_errors.append(msg)
+            finally:
+                self._clean_hardware_resources()
 
-            succeed_results[testcase.id] = (res, time)
-            succeed_testcases.append(testcase)
+        if not succeed_testcases and failed_errors:
+            raise RuntimeError(f"All testcases failed. Errors: {'; '.join(failed_errors)}")
 
         return succeed_testcases, succeed_results
+
+    @classmethod
+    def _clean_hardware_resources(cls):
+        """Clean memory and hardware caches after testcase execution."""
+        import gc
+        import sys
+
+        gc.collect()
+        if "torch" in sys.modules:
+            try:
+                torch = sys.modules["torch"]
+                if hasattr(torch, "cuda") and torch.cuda.is_available():
+                    torch.cuda.empty_cache()
+            except Exception:  # pylint: disable=broad-except
+                pass
 
     @classmethod
     def _parse_algorithms_config(cls, config):

--- a/tests/test_core_framework.py
+++ b/tests/test_core_framework.py
@@ -1,0 +1,185 @@
+# Copyright 2026 The KubeEdge Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests for core framework stability and resiliency fixes."""
+
+import os
+import sys
+import tempfile
+import uuid
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from core.common import utils
+from core.testcasecontroller.testcase.testcase import TestCase
+from core.testcasecontroller.testcasecontroller import TestCaseController
+from core.storymanager.rank.rank import Rank
+
+
+class MockAlgorithm:
+    def __init__(self, name="mock_algo"):
+        self.name = name
+
+
+class MockTestCase:
+    def __init__(self, tc_id, should_fail=False):
+        self.id = tc_id
+        self.should_fail = should_fail
+        self.algorithm = MockAlgorithm()
+
+    def run(self, workspace):
+        if self.should_fail:
+            raise RuntimeError(f"Mock failure for {self.id}")
+        return {"accuracy": 0.95}
+
+
+def test_get_output_dir_avoid_infinite_loop():
+    algorithm = MockAlgorithm("test_algo")
+    testcase = TestCase(test_env=None, algorithm=algorithm)
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Pre-create the initial output dir to simulate collision
+        initial_dir = os.path.join(tmp_dir, algorithm.name, str(testcase.id))
+        os.makedirs(initial_dir, exist_ok=True)
+
+        res_dir = testcase._get_output_dir(tmp_dir)
+        assert res_dir != initial_dir
+        assert res_dir.startswith(initial_dir)
+        assert "_1" in res_dir
+
+
+def test_run_testcases_partial_failure_retention():
+    controller = TestCaseController()
+    tc1 = MockTestCase(uuid.uuid4(), should_fail=False)
+    tc2 = MockTestCase(uuid.uuid4(), should_fail=True)
+    tc3 = MockTestCase(uuid.uuid4(), should_fail=False)
+
+    controller.test_cases = [tc1, tc2, tc3]
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        succeed_tcs, succeed_results = controller.run_testcases(tmp_dir)
+        assert len(succeed_tcs) == 2
+        assert len(succeed_results) == 2
+        assert tc1 in succeed_tcs
+        assert tc3 in succeed_tcs
+        assert tc2 not in succeed_tcs
+
+
+def test_run_testcases_all_failed_raises_runtime_error():
+    controller = TestCaseController()
+    tc1 = MockTestCase(uuid.uuid4(), should_fail=True)
+    tc2 = MockTestCase(uuid.uuid4(), should_fail=True)
+    controller.test_cases = [tc1, tc2]
+
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        with pytest.raises(RuntimeError) as exc_info:
+            controller.run_testcases(tmp_dir)
+        assert "All testcases failed" in str(exc_info.value)
+
+
+def test_rank_save_mode_str_validation():
+    config = {
+        "sort_by": [{"accuracy": "descend"}],
+        "visualization": {"mode": "selected_only", "method": "print_table"},
+        "selected_dataitem": {
+            "paradigms": ["all"],
+            "modules": ["all"],
+            "hyperparameters": ["all"],
+            "metrics": ["all"],
+        },
+        "save_mode": "selected_and_all"
+    }
+
+    rank = Rank(config)
+    assert rank.save_mode == "selected_and_all"
+
+
+def test_rank_draw_pictures_none_matrix_guard():
+    config = {
+        "sort_by": [{"accuracy": "descend"}],
+        "visualization": {"mode": "selected_only", "method": "print_table"},
+        "selected_dataitem": {
+            "paradigms": ["all"],
+            "modules": ["all"],
+            "hyperparameters": ["all"],
+            "metrics": ["all"],
+        },
+        "save_mode": "selected_and_all"
+    }
+    rank = Rank(config)
+
+    tc = MockTestCase(uuid.uuid4())
+    tc.output_dir = "/tmp/test"
+    test_results = {tc.id: ({"accuracy": 0.95, "Matrix": None}, "2026-08-01 00:00:00")}
+
+    # Should not raise AttributeError when matrix is None
+    rank._draw_pictures([tc], test_results)
+
+
+def test_py2dict_and_load_module():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        py_file = os.path.join(tmp_dir, "sample_config.py")
+        with open(py_file, "w", encoding="utf-8") as f:
+            f.write("KEY_A = 'VALUE_A'\nKEY_B = 123\n")
+
+        res_dict = utils.py2dict(py_file)
+        assert res_dict.get("KEY_A") == 'VALUE_A'
+        assert res_dict.get("KEY_B") == 123
+
+        mod = utils.load_module(py_file)
+        assert getattr(mod, "KEY_A") == 'VALUE_A'
+
+
+def test_load_module_failure_cleans_sys_path():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        missing_module = os.path.join(tmp_dir, "non_existent_module.py")
+        orig_sys_path = list(sys.path)
+        with pytest.raises(RuntimeError):
+            utils.load_module(missing_module)
+        assert sys.path == orig_sys_path
+
+
+def test_load_module_caching_and_collision():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        dir1 = os.path.join(tmp_dir, "algo1")
+        dir2 = os.path.join(tmp_dir, "algo2")
+        os.makedirs(dir1)
+        os.makedirs(dir2)
+
+        file1 = os.path.join(dir1, "basemodel.py")
+        file2 = os.path.join(dir2, "basemodel.py")
+
+        with open(file1, "w", encoding="utf-8") as f:
+            f.write("EXEC_COUNT = 1\nMODEL_VAL = 'model_1'\n")
+
+        with open(file2, "w", encoding="utf-8") as f:
+            f.write("EXEC_COUNT = 1\nMODEL_VAL = 'model_2'\n")
+
+        # Load file1
+        mod1_a = utils.load_module(file1)
+        assert mod1_a.MODEL_VAL == "model_1"
+
+        # Load file1 again -> should return cached mod1_a
+        mod1_b = utils.load_module(file1)
+        assert mod1_b is mod1_a
+
+        # Load file2 with same basename -> should reload to model_2
+        mod2 = utils.load_module(file2)
+        assert mod2.MODEL_VAL == "model_2"
+
+
+def test_clean_hardware_resources():
+    # Calling _clean_hardware_resources should execute without error
+    TestCaseController._clean_hardware_resources()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

This PR addresses four systemic core framework stability and resiliency issues in Ianvs:

1. **Infinite Loop Hang in Workspace Allocation**: Refactors `TestCase._get_output_dir` (`core/testcasecontroller/testcase/testcase.py`) to safely generate unique directory paths when directory name collisions occur, eliminating potential infinite `while` loops.
2. **Partial Result Retention on Testcase Failures**: Updates `TestCaseController.run_testcases` (`core/testcasecontroller/testcasecontroller.py`) to log errors for failed test cases while preserving and returning all successfully completed test case results to `Rank.save()`, preventing total data loss during benchmarking suite runs.
3. **Rank Validation & Matrix Guard Fixes**: Updates `Rank._check_fields()` (`core/storymanager/rank/rank.py`) to allow string type `save_mode` configurations and adds a dictionary type guard in `_draw_pictures()` to prevent `AttributeError` on non-matrix metrics.
4. **Dynamic Module Loading Isolation**: Refactors `py2dict` and `load_module` (`core/common/utils.py`) to use `importlib.util.spec_from_file_location` and `module_from_spec`, avoiding unsafe `sys.path` and `sys.modules` mutation.
5. **Unit Tests**: Adds comprehensive unit test coverage in `tests/test_core_framework.py`.

**Which issue(s) this PR fixes**:

Fixes #610

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
Fix infinite loop hangs, partial testcase failure result loss, and module loading side-effects in Ianvs core framework.
```
