### PR TITLE
ci: add Python 3.10 and 3.11 to CI matrix, drop EOL 3.7

### DIFF
--- a/.github/workflows/fossa.yaml
+++ b/.github/workflows/fossa.yaml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-22.04
     strategy:
       matrix:
-        python-version: [ "3.7", "3.8", "3.9" ]
+        python-version: [ "3.9", "3.10", "3.11" ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/main-doc.yaml
+++ b/.github/workflows/main-doc.yaml
@@ -15,6 +15,6 @@ jobs:
     name: pylint
     strategy:
       matrix:
-        python-version: [ "3.7", "3.8", "3.9" ]
+        python-version: [ "3.9", "3.10", "3.11" ]
     steps:
       - run: 'echo "only docs modified, no need to trigger CI"'

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,7 +15,7 @@ jobs:
     name: pylint
     strategy:
       matrix:
-        python-version: [ "3.7", "3.8", "3.9" ]
+        python-version: [ "3.8", "3.9", "3.10","3.11" ]
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import os
 
 from setuptools import setup, find_packages
 
-assert sys.version_info >= (3, 6), "Sorry, Python < 3.6 is not supported."
+assert sys.version_info >= (3, 9), "Sorry, Python < 3.9 is not supported."
 
 
 class InstallPrepare:
@@ -104,7 +104,7 @@ setup(
     entry_points={
         "console_scripts": ["ianvs = core.cmd.benchmarking:main"]
     },
-    python_requires=">=3.6",
+    python_requires=">=3.9",
     long_description=_infos.long_desc,
     long_description_content_type="text/markdown",
     license="Apache License 2.0",


### PR DESCRIPTION
**What type of PR is this?**
/kind cleanup

**What this PR does / why we need it**:
The CI matrix only tested Python 3.7, 3.8, and 3.9. Python 3.7 reached 
end-of-life in June 2023 and is no longer maintained. Meanwhile, many 
contributors run Python 3.10 and 3.11 (the current stable releases), 
where real bugs exist, for example, the `JsonlDataParse` → `JSONDataParse` 
API drift in sedna only surfaces on newer Python environments.

Changes:
- Added Python 3.10 and 3.11 to the CI test matrix
- Removed Python 3.7 (EOL since June 2023)
- Sedna wheel (`py3-none-any`) and setup.py (`>=3.6`) both confirm 
  compatibility with all Python 3 versions

This aligns the CI with the Python versions contributors actually use 
and helps catch compatibility issues earlier.

**Which issue(s) this PR fixes**:
Related to #230