### PR TITLE
fix(dataset): use np.isin for non-iid class membership check in partition_data

### DIFF
--- a/core/testenvmanager/dataset/utils.py
+++ b/core/testenvmanager/dataset/utils.py
@@ -88,7 +88,7 @@ def partition_data(datasets, client_number, data_partition="iid", non_iid_ratio=
             sample_number = int(class_num * non_iid_ratio)
             current_class = random.sample(range(class_num), sample_number)
             LOGGER.info(f"for client{i} the class is {current_class}")
-            indices = np.where(y_data == current_class)[0]
+            indices = np.where(np.isin(y_data, current_class))[0]
             data.append([x_data[indices], y_data[indices]])
     else:
         raise ValueError("paritiion_methods must be 'iid' or 'non-iid'")


### PR DESCRIPTION
## What this PR does

Fixes a type-mismatch bug in `partition_data()` in
`core/testenvmanager/dataset/utils.py` that breaks the `"non-iid"`
data partitioning path used for federated learning.

## Problem

In the `"non-iid"` branch, each client is assigned a random subset of
class IDs:

```python
current_class = random.sample(range(class_num), sample_number)
```

`current_class` is a Python `list` containing the class IDs assigned to
a client. The code then attempts to retrieve all samples belonging to
those classes using:

```python
indices = np.where(y_data == current_class)[0]
```

However:

- `y_data` is a NumPy array containing one label per sample (length =
  number of samples).
- `current_class` is a Python list of selected class IDs (length =
  number of classes assigned to that client).

These arrays have different shapes, so the expression:

```python
y_data == current_class
```

does **not** perform a membership test. Instead, NumPy attempts an
element-wise comparison between incompatible shapes.

As a result:

- On newer NumPy versions, this raises:

  ```
  ValueError: operands could not be broadcast together
  ```

- On older NumPy versions, it falls back to a scalar `False` comparison
  (with a `DeprecationWarning`), causing:

  ```python
  np.where(...)
  ```

  to return an empty index array.

In both cases, the `"non-iid"` partitioning path is broken—either by
raising an exception or by silently assigning empty datasets to clients.

## Fix

Replace the element-wise equality comparison with `np.isin()`, which
correctly performs a membership check across arrays of different
lengths.

```python
indices = np.where(np.isin(y_data, current_class))[0]
```