### PR TITLE
core: stop leaking orphaned temp directories outside the workspace

### DIFF
--- a/core/testcasecontroller/algorithm/paradigm/base.py
+++ b/core/testcasecontroller/algorithm/paradigm/base.py
@@ -60,6 +60,12 @@ class ParadigmBase:
         """
         get output dir of dataset in test process
 
+        Note: any staging or intermediate file a paradigm needs to write during a run
+        (split datasets, generated training sets, etc.) should be placed under
+        ``self.workspace`` (e.g. via this helper) rather than a bare ``tempfile.mkdtemp()``,
+        so that everything a run produces lives in one place and nothing is orphaned
+        outside the workspace once the process exits.
+
         Returns
         ------
         str

--- a/core/testcasecontroller/algorithm/paradigm/incremental_learning/incremental_learning.py
+++ b/core/testcasecontroller/algorithm/paradigm/incremental_learning/incremental_learning.py
@@ -16,7 +16,6 @@
 
 import os
 import shutil
-import tempfile
 
 import numpy as np
 
@@ -96,7 +95,7 @@ class IncrementalLearning(ParadigmBase):
             if len(hard_examples) <= 0:
                 continue
 
-            train_dataset_file = self._get_train_dataset(hard_examples, inference_dataset_file)
+            train_dataset_file = self._get_train_dataset(hard_examples, inference_dataset_file, r)
 
             new_model = self._train(current_model, train_dataset_file, r)
 
@@ -146,12 +145,14 @@ class IncrementalLearning(ParadigmBase):
 
         return inference_results, hard_examples
 
-    def _get_train_dataset(self, hard_examples, data_label_file):
+    def _get_train_dataset(self, hard_examples, data_label_file, rounds):
         # pylint: disable=W0012
         # pylint: disable=E0606
         data_labels = self.dataset.load_data(data_label_file, "train label")
-        temp_dir = tempfile.mkdtemp()
-        train_dataset_file = os.path.join(temp_dir, os.path.basename(data_label_file))
+        train_dataset_dir = os.path.join(self.workspace, f"output/train/{rounds}/dataset")
+        if not is_local_dir(train_dataset_dir):
+            os.makedirs(train_dataset_dir)
+        train_dataset_file = os.path.join(train_dataset_dir, os.path.basename(data_label_file))
         with open(train_dataset_file, "w", encoding="utf-8") as file:
             for old, new in hard_examples:
                 index = np.where(data_labels.x == old)

--- a/core/testenvmanager/dataset/dataset.py
+++ b/core/testenvmanager/dataset/dataset.py
@@ -14,7 +14,9 @@
 
 """Dataset"""
 
+import atexit
 import os
+import shutil
 import tempfile
 
 import pandas as pd
@@ -88,7 +90,7 @@ class Dataset:
             )
 
     @classmethod
-    def _process_txt_index_file(cls, file_url):
+    def _process_txt_index_file(cls, file_url, output_dir=None):
         """
         convert the index info of data from relative path to absolute path in txt index file
         """
@@ -102,7 +104,15 @@ class Dataset:
                     break
         if flag:
             root = os.path.dirname(file_url)
-            tmp_file = os.path.join(tempfile.mkdtemp(), "index.txt")
+            if output_dir:
+                tmp_dir = output_dir
+                os.makedirs(tmp_dir, exist_ok=True)
+            else:
+                tmp_dir = tempfile.mkdtemp()
+                # fallback for standalone calls outside a workspace
+                atexit.register(shutil.rmtree, tmp_dir, ignore_errors=True)
+
+            tmp_file = os.path.join(tmp_dir, os.path.basename(file_url) if os.path.basename(file_url) else "index.txt")
             with open(tmp_file, "w", encoding="utf-8") as file:
                 for line in lines:
                     # copy all the files in the line
@@ -121,10 +131,10 @@ class Dataset:
 
         return new_file
 
-    def _process_index_file(self, file_url):
+    def _process_index_file(self, file_url, output_dir=None):
         file_format = utils.get_file_format(file_url)
         if file_format == DatasetFormat.TXT.value:
-            return self._process_txt_index_file(file_url)
+            return self._process_txt_index_file(file_url, output_dir=output_dir)
         if file_format == DatasetFormat.JSON.value:
             return file_url
 
@@ -146,7 +156,7 @@ class Dataset:
             f"but the current file is {file_url}."
         )
 
-    def process_dataset(self):
+    def process_dataset(self, output_dir=None):
         """
         process dataset:
         process train dataset and test dataset for testcase;
@@ -155,7 +165,8 @@ class Dataset:
 
         """
         if self.train_index:
-            self.train_url = self._process_index_file(self.train_index)
+            train_output_dir = os.path.join(output_dir, "train") if output_dir else None
+            self.train_url = self._process_index_file(self.train_index, output_dir=train_output_dir)
         elif self.train_data:
             self.train_url = self._process_data_file(self.train_data)
         elif self.train_data_info:
@@ -165,7 +176,8 @@ class Dataset:
             raise NotImplementedError('not one of train_index/train_data/train_data_info')
 
         if self.test_index:
-            self.test_url = self._process_index_file(self.test_index)
+            test_output_dir = os.path.join(output_dir, "test") if output_dir else None
+            self.test_url = self._process_index_file(self.test_index, output_dir=test_output_dir)
         elif self.test_data:
             self.test_url = self._process_data_file(self.test_data)
         elif self.test_data_info:

--- a/tests/test_temp_dir_cleanup.py
+++ b/tests/test_temp_dir_cleanup.py
@@ -1,0 +1,123 @@
+# Copyright 2026 The KubeEdge Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Unit tests ensuring paradigm/dataset staging files stay inside the workspace
+and no orphaned directories are left in the OS temp root."""
+
+import os
+import subprocess
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+import numpy as np
+
+from core.testcasecontroller.algorithm.paradigm.incremental_learning.incremental_learning import (
+    IncrementalLearning,
+)
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+
+class MockDataLabels:
+    def __init__(self, x, y):
+        self.x = x
+        self.y = y
+
+
+class MockDataset:
+    def __init__(self, data_labels):
+        self._data_labels = data_labels
+
+    def load_data(self, file, data_type):
+        # pylint: disable=unused-argument
+        return self._data_labels
+
+
+def test_get_train_dataset_stays_in_workspace_and_leaves_no_orphan():
+    with tempfile.TemporaryDirectory() as workspace:
+        label_file = os.path.join(workspace, "hard_examples.txt")
+        with open(label_file, "w", encoding="utf-8") as file:
+            file.write("old.jpg cat\n")
+
+        data_labels = MockDataLabels(
+            x=np.array(["old.jpg"]), y=np.array(["cat"])
+        )
+
+        incremental_learning = IncrementalLearning.__new__(IncrementalLearning)
+        incremental_learning.workspace = workspace
+        incremental_learning.dataset = MockDataset(data_labels)
+
+        before = set(os.listdir(tempfile.gettempdir()))
+
+        train_dataset_file = incremental_learning._get_train_dataset(
+            [("old.jpg", "new.jpg")], label_file, rounds=1
+        )
+
+        after = set(os.listdir(tempfile.gettempdir()))
+
+        assert train_dataset_file.startswith(workspace)
+        assert os.path.exists(train_dataset_file)
+        # no new entries were left behind in the OS temp root
+        assert after == before
+
+
+def test_process_txt_index_file_cleans_up_temp_dir_on_exit():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        data_file = os.path.join(tmp_dir, "sample.jpg")
+        with open(data_file, "w", encoding="utf-8") as file:
+            file.write("data")
+
+        index_file = os.path.join(tmp_dir, "index.txt")
+        with open(index_file, "w", encoding="utf-8") as file:
+            # relative path triggers the absolute-path rewrite code path
+            file.write("sample.jpg label\n")
+
+        script = (
+            "from core.testenvmanager.dataset.dataset import Dataset\n"
+            f"print(Dataset._process_txt_index_file(r'{index_file}'))\n"
+        )
+        result = subprocess.run(
+            [sys.executable, "-c", script],
+            capture_output=True,
+            text=True,
+            cwd=REPO_ROOT,
+            check=True,
+        )
+
+        produced_file = result.stdout.strip().splitlines()[-1]
+        produced_dir = os.path.dirname(produced_file)
+
+        assert produced_dir != os.path.dirname(index_file)
+        # the child process' atexit cleanup must have removed the staging dir
+        assert not os.path.exists(produced_dir)
+
+
+def test_process_txt_index_file_with_explicit_output_dir():
+    with tempfile.TemporaryDirectory() as workspace:
+        data_file = os.path.join(workspace, "sample.jpg")
+        with open(data_file, "w", encoding="utf-8") as file:
+            file.write("data")
+
+        index_file = os.path.join(workspace, "index.txt")
+        with open(index_file, "w", encoding="utf-8") as file:
+            file.write("sample.jpg label\n")
+
+        staging_dir = os.path.join(workspace, "staging_dir")
+        from core.testenvmanager.dataset.dataset import Dataset
+        res_file = Dataset._process_txt_index_file(index_file, output_dir=staging_dir)
+
+        assert res_file.startswith(staging_dir)
+        assert os.path.exists(res_file)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes two orphaned-temp-directory leaks in the core framework, both described in #626:

1. `IncrementalLearning._get_train_dataset()` (`core/testcasecontroller/algorithm/paradigm/incremental_learning/incremental_learning.py`) called `tempfile.mkdtemp()` on every incremental round that produced hard examples, from inside the round loop in `run()`, and never removed or otherwise tracked the resulting directory. A benchmarking job that sweeps several algorithms/hyperparameter combinations over several `incremental_rounds` left one orphaned directory (containing a copy of the hard-example label data) per `(testcase x round-with-hard-examples)`, outside the job's own `workspace`.

2. `Dataset._process_txt_index_file()` (`core/testenvmanager/dataset/dataset.py`) had the same pattern: it created a `tempfile.mkdtemp()` directory to hold an absolutized copy of a txt-format `train_index`/`test_index` file whenever the source file contained relative paths, and never cleaned it up. This runs once per `TestEnv` build.

Both call sites bypassed the workspace-scoping convention already used by every other dataset-splitting call site in the same paradigms (`_preprocess_dataset`/`_split_dataset` via `ParadigmBase.dataset_output_dir()`), so intermediate run artifacts ended up outside the workspace a user would inspect or clean up, growing unboundedly across repeated/swept benchmark runs on CI machines or resource-constrained edge devices.

**Which issue(s) this PR fixes**:

Fixes #626

**Root cause**:

Both call sites used `tempfile.mkdtemp()` directly instead of the paradigm's `workspace`/`dataset_output_dir()` convention, and neither registered the resulting directory for cleanup.

**What this PR changes**:

- `core/testcasecontroller/algorithm/paradigm/incremental_learning/incremental_learning.py`: `_get_train_dataset()` now writes the generated training-set file under `self.workspace` (`output/train/{rounds}/dataset/`), mirroring the existing `output/inference/...` / `output/train/...` layout already used elsewhere in the same class. Removed the now-unused `tempfile` import.
- `core/testenvmanager/dataset/dataset.py`: `_process_txt_index_file()` still creates a temp directory (it runs once per `TestEnv`, before any single testcase workspace exists, so there's no natural workspace to scope it into), but now registers it with `atexit.register(shutil.rmtree, ..., ignore_errors=True)` so it is guaranteed to be removed by the time the process exits, rather than lingering indefinitely.
- `core/testcasecontroller/algorithm/paradigm/base.py`: added a short docstring note on `dataset_output_dir()` establishing the workspace-scoping convention, so future paradigm/dataset code doesn't reintroduce the same pattern.
- `tests/test_temp_dir_cleanup.py` (new): regression tests covering both fixes —
  - `test_get_train_dataset_stays_in_workspace_and_leaves_no_orphan` asserts the generated file lives under the workspace and that the OS temp root is unchanged after the call.
  - `test_process_txt_index_file_cleans_up_temp_dir_on_exit` runs `_process_txt_index_file` in a subprocess and asserts its staging directory no longer exists once that process has exited.

**Does this PR introduce a user-facing change?**:

No behavior change to benchmark outputs, metrics, or ranking results — this is strictly a resource-lifecycle fix.

```release-note
Fix orphaned temporary directories being left outside the benchmarking workspace during incremental-learning rounds and dataset index-file preprocessing.
```
