### PR TITLE
fix(dataset): preserve non-path labels in txt index file preprocessing

### DIFF
--- a/core/testenvmanager/dataset/dataset.py
+++ b/core/testenvmanager/dataset/dataset.py
@@ -88,34 +88,60 @@ class Dataset:
             )
 
     @classmethod
+    def _is_path_token(cls, word, root):
+        if not word:
+            return False
+        if os.path.isabs(word):
+            return True
+        if "/" in word or "\\" in word or word.startswith("."):
+            return True
+        ext = os.path.splitext(word)[1].lower()
+        if ext and len(ext) > 1 and ext[1:].isalnum() and not ext[1:].isdigit():
+            return True
+        if os.path.isfile(os.path.join(root, word)):
+            return True
+        return False
+
+    @classmethod
     def _process_txt_index_file(cls, file_url):
         """
         convert the index info of data from relative path to absolute path in txt index file
         """
+        import re
+
         flag = False
         new_file = file_url
+        root = os.path.dirname(file_url)
         with open(file_url, "r", encoding="utf-8") as file:
             lines = file.readlines()
             for line in lines:
-                if not os.path.isabs(line.split(" ")[0]):
-                    flag = True
+                stripped_line = line.strip()
+                if not stripped_line:
+                    continue
+                tokens = [t for t in re.split(r"[\t ]+", stripped_line) if t]
+                for token in tokens:
+                    if cls._is_path_token(token, root) and not os.path.isabs(token):
+                        flag = True
+                        break
+                if flag:
                     break
         if flag:
-            root = os.path.dirname(file_url)
             tmp_file = os.path.join(tempfile.mkdtemp(), "index.txt")
             with open(tmp_file, "w", encoding="utf-8") as file:
                 for line in lines:
-                    # copy all the files in the line
-                    line = line.strip()
-                    words = line.split(" ")
-                    length = len(words)
-                    words[-1] = words[-1] + "\n"
-                    for i in range(length):
-                        file.writelines(
-                            f"{os.path.abspath(os.path.join(root, words[i]))}"
-                        )
-                        if i < length - 1:
-                            file.writelines(" ")
+                    stripped_line = line.strip()
+                    if not stripped_line:
+                        file.write("\n")
+                        continue
+                    delimiter = "\t" if "\t" in line else " "
+                    tokens = [t for t in re.split(r"[\t ]+", stripped_line) if t]
+                    processed_tokens = []
+                    for token in tokens:
+                        if cls._is_path_token(token, root) and not os.path.isabs(token):
+                            processed_tokens.append(os.path.abspath(os.path.join(root, token)))
+                        else:
+                            processed_tokens.append(token)
+                    file.write(delimiter.join(processed_tokens) + "\n")
 
             new_file = tmp_file
 

--- a/tests/test_txt_index_file.py
+++ b/tests/test_txt_index_file.py
@@ -1,0 +1,110 @@
+# Copyright 2026 The KubeEdge Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import tempfile
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from core.testenvmanager.dataset import Dataset
+
+
+def test_process_txt_index_file_path_label_disambiguation():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        index_file = os.path.join(tmp_dir, "train_index.txt")
+        lines = [
+            "./images/img01.jpg 1\n",
+            "./images/img02.jpg 0\n",
+            "./images/img03.jpg ./annotations/ann03.xml\n"
+        ]
+        with open(index_file, "w", encoding="utf-8") as f:
+            f.writelines(lines)
+
+        processed_file = Dataset._process_txt_index_file(index_file)
+
+        assert os.path.exists(processed_file)
+        with open(processed_file, "r", encoding="utf-8") as f:
+            processed_lines = [l.strip() for l in f.readlines()]
+
+        expected_img01_path = os.path.abspath(os.path.join(tmp_dir, "./images/img01.jpg"))
+        expected_img02_path = os.path.abspath(os.path.join(tmp_dir, "./images/img02.jpg"))
+        expected_img03_path = os.path.abspath(os.path.join(tmp_dir, "./images/img03.jpg"))
+        expected_ann03_path = os.path.abspath(os.path.join(tmp_dir, "./annotations/ann03.xml"))
+
+        # Verify image paths are absolute and non-path labels ("1", "0") are preserved
+        assert processed_lines[0] == f"{expected_img01_path} 1"
+        assert processed_lines[1] == f"{expected_img02_path} 0"
+        assert processed_lines[2] == f"{expected_img03_path} {expected_ann03_path}"
+
+
+def test_process_txt_index_file_cifar100_tab_format():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        index_file = os.path.join(tmp_dir, "cifar100_train.txt")
+        lines = [
+            "cifar100_train_index_0.npy\t0\n",
+            "cifar100_train_index_1.npy\t1\n"
+        ]
+        with open(index_file, "w", encoding="utf-8") as f:
+            f.writelines(lines)
+
+        processed_file = Dataset._process_txt_index_file(index_file)
+        with open(processed_file, "r", encoding="utf-8") as f:
+            processed_lines = f.readlines()
+
+        expected_0 = os.path.abspath(os.path.join(tmp_dir, "cifar100_train_index_0.npy"))
+        expected_1 = os.path.abspath(os.path.join(tmp_dir, "cifar100_train_index_1.npy"))
+
+        assert processed_lines[0] == f"{expected_0}\t0\n"
+        assert processed_lines[1] == f"{expected_1}\t1\n"
+
+
+def test_process_txt_index_file_absolute_first_relative_second():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        index_file = os.path.join(tmp_dir, "dataset_index.txt")
+        abs_img = os.path.abspath(os.path.join(tmp_dir, "img.jpg"))
+        rel_ann = "./annotations/ann.xml"
+        lines = [
+            f"{abs_img} {rel_ann}\n"
+        ]
+        with open(index_file, "w", encoding="utf-8") as f:
+            f.writelines(lines)
+
+        processed_file = Dataset._process_txt_index_file(index_file)
+        with open(processed_file, "r", encoding="utf-8") as f:
+            processed_lines = f.readlines()
+
+        expected_ann = os.path.abspath(os.path.join(tmp_dir, rel_ann))
+        assert processed_lines[0] == f"{abs_img} {expected_ann}\n"
+
+
+def test_process_txt_index_file_directory_name_collision_with_label():
+    with tempfile.TemporaryDirectory() as tmp_dir:
+        # Create an unrelated local directory named "cat"
+        os.makedirs(os.path.join(tmp_dir, "cat"), exist_ok=True)
+
+        index_file = os.path.join(tmp_dir, "train_index.txt")
+        lines = [
+            "./images/img.jpg cat\n"
+        ]
+        with open(index_file, "w", encoding="utf-8") as f:
+            f.writelines(lines)
+
+        processed_file = Dataset._process_txt_index_file(index_file)
+        with open(processed_file, "r", encoding="utf-8") as f:
+            processed_lines = f.readlines()
+
+        expected_img = os.path.abspath(os.path.join(tmp_dir, "./images/img.jpg"))
+        # Label "cat" must remain unchanged as label, NOT converted to tmp_dir/cat
+        assert processed_lines[0] == f"{expected_img} cat\n"


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes the path/label disambiguation gap in `Dataset._process_txt_index_file()` (`core/testenvmanager/dataset/dataset.py`).

Previously, `_process_txt_index_file()` read each line of a `.txt` index file and unconditionally applied `os.path.abspath(os.path.join(root, word))` to every whitespace-separated token. When index files include non-path tokens such as bare numeric class labels (e.g. `./images/img1.jpg 1`), the numeric label `1` was silently rewritten into an absolute filesystem path `/path/to/root/1`.

Changes Introduced:
1. **Token-Level Path Identification (`_is_path_token`)**:
   Added `@classmethod _is_path_token(cls, word, root)` to check whether a token is a file path (contains `/` or `\`, starts with `.`, exists relative to `root`, or is an absolute path).
2. **Preserve Non-Path Labels**:
   Updated `_process_txt_index_file()` to rewrite only relative file path tokens to absolute paths while preserving non-path tokens (like class labels `"0"`, `"1"`, `"cat"`) as-is.
3. **Unit Tests**:
   Added `tests/test_txt_index_file.py` to verify path resolution for relative file paths and preservation of non-path labels.

**Which issue(s) this PR fixes**:

Fixes #639

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
Fix Dataset._process_txt_index_file() to preserve non-path class labels when rewriting relative file paths to absolute paths in text index files.
```
