### PR TITLE
fix(metrics): resolve NoneType crashes, transfer ratio math error, and metric lookup guardrails

### DIFF
--- a/core/testcasecontroller/metrics/metrics.py
+++ b/core/testcasecontroller/metrics/metrics.py
@@ -25,7 +25,7 @@ from core.common.utils import load_module
 def samples_transfer_ratio_func(system_metric_info: dict):
     """
     compute samples transfer ratio:
-        ratio = nums of all inference samples / nums of all transfer samples
+        ratio = nums of all transfer samples / nums of all inference samples
 
     Parameters
     ----------
@@ -36,22 +36,34 @@ def samples_transfer_ratio_func(system_metric_info: dict):
     -------
     float
         e.g.: 0.92
-
     """
+    if not system_metric_info:
+        return np.nan
 
     info = system_metric_info.get(SystemMetricType.SAMPLES_TRANSFER_RATIO.value)
+    if not info or not isinstance(info, (list, tuple)):
+        return np.nan
+
     inference_num = 0
     transfer_num = 0
-    for inference_data, transfer_data in info:
-        inference_num += len(inference_data)
-        transfer_num += len(transfer_data)
-    return round(float(transfer_num) / (inference_num + 1), 4)
+    for item in info:
+        if isinstance(item, (list, tuple)) and len(item) == 2:
+            inference_data, transfer_data = item
+            inference_num += len(inference_data) if hasattr(inference_data, "__len__") else 0
+            transfer_num += len(transfer_data) if hasattr(transfer_data, "__len__") else 0
+
+    if inference_num == 0:
+        return 0.0 if transfer_num == 0 else np.nan
+
+    return round(float(transfer_num) / float(inference_num), 4)
 
 
 def compute(key, matrix):
     """
     Compute BWT and FWT scores for a given matrix.
     """
+    if not matrix or not isinstance(matrix, list) or len(matrix) <= 1:
+        return [], np.nan, np.nan
 
     length = len(matrix)
     accuracy = 0.0
@@ -67,7 +79,7 @@ def compute(key, matrix):
     if not flag:
         bwt_score = np.nan
         fwt_score = np.nan
-        return bwt_score, fwt_score
+        return [], bwt_score, fwt_score
 
     for i in range(length - 1):
         for j in range(length - 1):
@@ -102,7 +114,11 @@ def bwt_func(system_metric_info: dict):
     """
     # pylint: disable=C0103
     # pylint: disable=W0632
+    if not system_metric_info:
+        return np.nan
     info = system_metric_info.get(SystemMetricType.MATRIX.value)
+    if not info or not isinstance(info, dict) or "all" not in info:
+        return np.nan
     _, BWT_score, _ = compute("all", info["all"])
     return BWT_score
 
@@ -113,7 +129,11 @@ def fwt_func(system_metric_info: dict):
     """
     # pylint: disable=C0103
     # pylint: disable=W0632
+    if not system_metric_info:
+        return np.nan
     info = system_metric_info.get(SystemMetricType.MATRIX.value)
+    if not info or not isinstance(info, dict) or "all" not in info:
+        return np.nan
     _, _, FWT_score = compute("all", info["all"])
     return FWT_score
 
@@ -124,7 +144,11 @@ def matrix_func(system_metric_info: dict):
     """
     # pylint: disable=C0103
     # pylint: disable=W0632
+    if not system_metric_info:
+        return {}
     info = system_metric_info.get(SystemMetricType.MATRIX.value)
+    if not info or not isinstance(info, dict):
+        return {}
     my_dict = {}
     for key in info.keys():
         my_matrix, _, _ = compute(key, info[key])
@@ -136,7 +160,11 @@ def task_avg_acc_func(system_metric_info: dict):
     """
     compute task average accuracy
     """
+    if not system_metric_info:
+        return np.nan
     info = system_metric_info.get(SystemMetricType.TASK_AVG_ACC.value)
+    if not info or not isinstance(info, dict) or "accuracy" not in info:
+        return np.nan
     return round(info["accuracy"], 3)
 
 
@@ -144,9 +172,18 @@ def forget_rate_func(system_metric_info: dict):
     """
     compute task forget rate
     """
+    if not system_metric_info:
+        return np.nan
     info = system_metric_info.get(SystemMetricType.FORGET_RATE.value)
-    forget_rate = np.mean(info)
-    return round(forget_rate, 3)
+    if info is None or (hasattr(info, "__len__") and len(info) == 0):
+        return np.nan
+    try:
+        forget_rate = np.mean(info)
+        if np.isnan(forget_rate):
+            return np.nan
+        return round(float(forget_rate), 3)
+    except Exception:
+        return np.nan
 
 
 def get_metric_func(metric_dict: dict):
@@ -179,4 +216,11 @@ def get_metric_func(metric_dict: dict):
                 f"get metric func(url={url}) failed, error: {err}."
             ) from err
 
-    return name, getattr(sys.modules[__name__], str.lower(name) + "_func")
+    func_name = str.lower(name) + "_func" if name else ""
+    if func_name and hasattr(sys.modules[__name__], func_name):
+        return name, getattr(sys.modules[__name__], func_name)
+
+    raise ValueError(
+        f"metric func for '{name}' is not found in built-in metrics "
+        f"and no external plugin url was provided."
+    )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,0 +1,87 @@
+# Copyright 2026 The KubeEdge Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+import sys
+import numpy as np
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from core.testcasecontroller.metrics.metrics import (
+    samples_transfer_ratio_func,
+    task_avg_acc_func,
+    forget_rate_func,
+    bwt_func,
+    fwt_func,
+    matrix_func,
+    compute,
+    get_metric_func,
+)
+
+
+def test_samples_transfer_ratio_func():
+    # Empty / None info returns nan
+    assert np.isnan(samples_transfer_ratio_func(None))
+    assert np.isnan(samples_transfer_ratio_func({}))
+
+    # Valid data calculation (exact ratio without artificial +1 denominator offset)
+    info = {
+        "samples_transfer_ratio": [
+            ([1, 2, 3, 4, 5, 6, 7, 8, 9, 10], [1, 2, 3, 4, 5]),  # 10 inference, 5 transfer
+        ]
+    }
+    assert samples_transfer_ratio_func(info) == 0.5
+
+
+def test_task_avg_acc_func():
+    assert np.isnan(task_avg_acc_func(None))
+    assert np.isnan(task_avg_acc_func({}))
+    assert task_avg_acc_func({"task_avg_acc": {"accuracy": 0.8567}}) == 0.857
+
+
+def test_forget_rate_func():
+    assert np.isnan(forget_rate_func(None))
+    assert np.isnan(forget_rate_func({}))
+    assert np.isnan(forget_rate_func({"forget_rate": []}))
+    assert forget_rate_func({"forget_rate": [0.1, 0.2, 0.3]}) == 0.2
+
+
+def test_compute_and_bwt_fwt_matrix_func():
+    # Invalid or empty matrix returns 3-tuple with [] and NaNs
+    res, bwt, fwt = compute("test", None)
+    assert res == []
+    assert np.isnan(bwt)
+    assert np.isnan(fwt)
+
+    # Single-row matrix [[]] (length <= 1) should not trigger ZeroDivisionError
+    res_single, bwt_single, fwt_single = compute("test", [[]])
+    assert res_single == []
+    assert np.isnan(bwt_single)
+    assert np.isnan(fwt_single)
+
+    res_empty, bwt_empty, fwt_empty = compute("test", [])
+    assert res_empty == []
+    assert np.isnan(bwt_empty)
+    assert np.isnan(fwt_empty)
+
+    # Missing info in bwt/fwt/matrix functions returns nan or empty dict
+    assert np.isnan(bwt_func(None))
+    assert np.isnan(fwt_func(None))
+    assert matrix_func(None) == {}
+
+
+def test_get_metric_func_unsupported_name():
+    with pytest.raises(ValueError, match="not found in built-in metrics"):
+        get_metric_func({"name": "unsupported_custom_metric_xyz"})


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Fixes several systemic defects in the system metrics evaluation subsystem (`core/testcasecontroller/metrics/metrics.py`):

1. **Defensive Validation for Missing System Metric Data**:
   Added `system_metric_info` and metric-specific payload checks across built-in metric functions (`samples_transfer_ratio_func`, `task_avg_acc_func`, `forget_rate_func`, `bwt_func`, `fwt_func`, `matrix_func`). When metric data is missing, empty, or `None`, the functions now gracefully return `np.nan` (or `{}` for matrix metrics) instead of crashing with `TypeError: 'NoneType' object is not iterable / subscriptable` or `KeyError`.

2. **Accurate Transfer Ratio Calculation**:
   Fixed mathematical ratio calculation in `samples_transfer_ratio_func()`:
   - Removed artificial `+ 1` denominator offset (`transfer_num / (inference_num + 1)`) to compute the exact ratio `transfer_num / inference_num`.
   - Added explicit zero-check handling when `inference_num == 0`.

3. **Consistent Tuple Unpacking & Metric Lookup Guardrails**:
   - Updated `compute()` to consistently return a 3-tuple (`[], np.nan, np.nan`) when matrix inputs are invalid, preventing 2-tuple vs 3-tuple unpacking crashes.
   - Updated `get_metric_func()` to check for function existence in `sys.modules` and raise a clear `ValueError` when an unknown metric name is specified without an external plugin `url`.

4. **Unit Tests**:
   Added `tests/test_metrics.py` covering system metric functions (`samples_transfer_ratio_func`, `task_avg_acc_func`, `forget_rate_func`, `bwt_func`, `fwt_func`, `matrix_func`), missing data handling, zero denominators, and metric lookup error handling (`5 passed`).

**Which issue(s) this PR fixes**:

Fixes #647

**Special notes for your reviewer**:

NONE

**Does this PR introduce a user-facing change?**:

```release-note
Fix system metrics evaluation subsystem to defensively handle missing metric data, ensure exact sample transfer ratio calculation, and prevent NoneType crashes.
```
