### PR TITLE
fix(examples): MATPLOTLIB_AVAILABLE and OPEN3D_AVAILABLE always False — add conditional imports to enable visualization in pose-estimation-llio

### DIFF
--- a/examples/industrialEI/pose-estimation-llio/testalgorithms/llio_fusion/utils.py
+++ b/examples/industrialEI/pose-estimation-llio/testalgorithms/llio_fusion/utils.py
@@ -7,8 +7,20 @@ from functools import wraps
 import time
 from core.common.log import LOGGER
 
-MATPLOTLIB_AVAILABLE = False
-OPEN3D_AVAILABLE = False
+try:
+    import matplotlib
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Ellipse
+    from matplotlib.collections import PatchCollection
+    MATPLOTLIB_AVAILABLE = True
+except ImportError:
+    MATPLOTLIB_AVAILABLE = False
+
+try:
+    import open3d as o3d
+    OPEN3D_AVAILABLE = True
+except ImportError:
+    OPEN3D_AVAILABLE = False
 
 
 def timeit(func):


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
`MATPLOTLIB_AVAILABLE` and `OPEN3D_AVAILABLE` flags in `pose-estimation-llio/testalgorithms/llio_fusion/utils.py` were hardcoded to `False` at module level:

```python
MATPLOTLIB_AVAILABLE = False
OPEN3D_AVAILABLE = False
```

This meant visualization and point-cloud features were permanently disabled even when `matplotlib` and `open3d` are installed. Worse, functions like `visualize()`, `plot_gaussian()`, `velo2downpcd()` reference `plt`, `o3d`, `Ellipse`, and `PatchCollection` — none of which were ever imported — causing runtime failures if the flags were manually set to `True`.

This PR replaces the hardcoded flags with proper `try/except` import blocks:

```python
try:
    import matplotlib
    import matplotlib.pyplot as plt
    from matplotlib.patches import Ellipse
    from matplotlib.collections import PatchCollection
    MATPLOTLIB_AVAILABLE = True
except ImportError:
    MATPLOTLIB_AVAILABLE = False

try:
    import open3d as o3d
    OPEN3D_AVAILABLE = True
except ImportError:
    OPEN3D_AVAILABLE = False
```

Now the flags correctly reflect whether the libraries are actually available at runtime, and all dependent symbols are properly imported when the libraries are present.

**Which issue(s) this PR fixes**:
Fixes #635