### PR TITLE
fix(deps): add missing colorlog to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas
 tqdm
 matplotlib
 onnx
+colorlog

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,9 @@
 prettytable~=2.5.0 # BSD
+colorlog # MIT
+PyYAML # MIT
 scikit-learn
 numpy
 pandas
 tqdm
 matplotlib
 onnx
-colorlog


### PR DESCRIPTION
Resolves #673 by adding `colorlog` to `requirements.txt`. 

The `Logger` class in `core/common/log.py` explicitly imports `colorlog`, but it was missing from the dependencies list, causing `ModuleNotFoundError` on fresh installations.
