### PR TITLE
cleanup: replace raw print calls with LOGGER in core modules

### DIFF
--- a/core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py
+++ b/core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py
@@ -300,7 +300,6 @@ class LifelongLearning(ParadigmBase):
 
     def _inference(self, edge_task_index, data_index_file, rounds):
         # pylint:disable=duplicate-code
-        #print("start inference")
         output_dir = os.path.join(self.workspace,
                                   f"output/inference/results/{rounds}")
         if not is_local_dir(output_dir):
@@ -329,7 +328,6 @@ class LifelongLearning(ParadigmBase):
             # fix the bug of "TypeError: call() got an unexpected keyword argument 'mode'"
         else:
             kwargs = {"mode": mode}
-        #print(len(inference_dataset.x))
         for i, _ in enumerate(inference_dataset.x):
             data = BaseDataSource(data_type="test")
             data.x = inference_dataset.x[i:(i + 1)]

--- a/core/testcasecontroller/algorithm/paradigm/singletask_learning/singletask_learning_tta.py
+++ b/core/testcasecontroller/algorithm/paradigm/singletask_learning/singletask_learning_tta.py
@@ -11,6 +11,7 @@ import os
 import torch
 from mmdet.apis import init_detector
 from core.common.constant import ParadigmType
+from core.common.log import LOGGER
 from examples.yaoba.singletask_learning_yolox_tta.resource.utils.TTA_strategy import TTA_Strategy
 from .singletask_learning import SingleTaskLearning
 
@@ -52,7 +53,7 @@ class SingleTaskLearningTTA(SingleTaskLearning):
 
         # Perform inference with data augmentation policy.
         job.load(trained_model)
-        print(f"Total infer strategy is :{strategy}")
+        LOGGER.info(f"Total infer strategy is :{strategy}")
         infer_res = job.tta_predict(test_set, strategy)
 
         return infer_res

--- a/core/testcasecontroller/metrics/metrics.py
+++ b/core/testcasecontroller/metrics/metrics.py
@@ -20,6 +20,7 @@ from sedna.common.class_factory import ClassFactory, ClassType
 
 from core.common.constant import SystemMetricType
 from core.common.utils import load_module
+from core.common.log import LOGGER
 
 
 def samples_transfer_ratio_func(system_metric_info: dict):
@@ -83,8 +84,8 @@ def compute(key, matrix):
     bwt_score = bwt_score / ((length - 1) * (length - 1))
     fwt_score = fwt_score / (length - 1)
 
-    print(f"{key} BWT_score: {bwt_score}")
-    print(f"{key} FWT_score: {fwt_score}")
+    LOGGER.info(f"{key} BWT_score: {bwt_score}")
+    LOGGER.info(f"{key} FWT_score: {fwt_score}")
 
     my_matrix = []
     for i in range(length - 1):


### PR DESCRIPTION
Resolves #675 by standardizing logging across core modules.

Changes made:
1. Replaced raw `print()` statements with `LOGGER.info()` in `core/testcasecontroller/metrics/metrics.py`.
2. Replaced raw `print()` statements with `LOGGER.info()` in `core/testcasecontroller/algorithm/paradigm/singletask_learning/singletask_learning_tta.py`.
3. Added the missing `from core.common.log import LOGGER` imports to both files.
4. Removed leftover commented-out debug prints from `core/testcasecontroller/algorithm/paradigm/lifelong_learning/lifelong_learning.py`.
