### PR TITLE
Remove self referential ianvs dependency

### DIFF
--- a/examples/GovDoc2Poster/singletask_learning_bench/requirements.txt
+++ b/examples/GovDoc2Poster/singletask_learning_bench/requirements.txt
@@ -2,7 +2,6 @@
 # 新版政府代理依赖包
 
 # Core dependencies
-ianvs>=0.1.0
 sedna>=0.1.0
 
 # Document processing (轻量级方案)

--- a/examples/imagenet/multiedge_inference_bench/requirements.txt
+++ b/examples/imagenet/multiedge_inference_bench/requirements.txt
@@ -24,7 +24,6 @@ h11==0.14.0
 h5py==3.8.0
 huggingface-hub==0.16.4
 humanfriendly==10.0
-ianvs>=0.3.0
 idna==3.7
 imageio==2.31.2
 importlib-metadata==6.7.0

--- a/examples/industrialEI/pose-estimation-llio/testalgorithms/llio_fusion/utils.py
+++ b/examples/industrialEI/pose-estimation-llio/testalgorithms/llio_fusion/utils.py
@@ -7,8 +7,20 @@ from functools import wraps
 import time
 from core.common.log import LOGGER
 
-MATPLOTLIB_AVAILABLE = False
-OPEN3D_AVAILABLE = False
+try:
+    import matplotlib
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Ellipse
+    from matplotlib.collections import PatchCollection
+    MATPLOTLIB_AVAILABLE = True
+except ImportError:
+    MATPLOTLIB_AVAILABLE = False
+
+try:
+    import open3d as o3d
+    OPEN3D_AVAILABLE = True
+except ImportError:
+    OPEN3D_AVAILABLE = False
 
 
 def timeit(func):


### PR DESCRIPTION
/kind bug

**What this PR does / why we need it**:
`pip install -r requirements.txt` fails for two examples because their `requirements.txt` lists `ianvs` itself as a pinned pip dependency:

- `examples/GovDoc2Poster/singletask_learning_bench/requirements.txt` → `ianvs>=0.1.0`
- `examples/imagenet/multiedge_inference_bench/requirements.txt` → `ianvs>=0.3.0`

`ianvs` is not published on PyPI — it is installed from source via `python setup.py install` per the Quick Start guide. This self-referential dependency breaks the install for any new user following the documented setup.

This PR removes the two offending lines. `sedna>=0.1.0` in GovDoc2Poster is intentionally kept — Sedna is genuinely published on PyPI.

**Which issue(s) this PR fixes**:
Fixes #644