### PR TITLE
build: update CI to test Python 3.9-3.12 and drop EOL versions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -15,11 +15,11 @@ jobs:
     name: pylint
     strategy:
       matrix:
-        python-version: [ "3.7", "3.8", "3.9" ]
+        python-version: [ "3.9", "3.10", "3.11", "3.12" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -31,11 +31,7 @@ jobs:
           python -m pip install ${{github.workspace}}/resources/third_party/*
           python -m pip install -r ${{github.workspace}}/requirements.txt
       - name: Analysing code of core with pylint
-        # `--max-positional-arguments=10` is set for Python 3.9 to avoid `R0917: too-many-positional-arguments`.
+        # `--max-positional-arguments=10` is set for Python >= 3.9 to avoid `R0917: too-many-positional-arguments`.
         # See details at https://github.com/kubeedge/ianvs/issues/157
         run: |
-          if [ "${{ matrix.python-version }}" = "3.9" ]; then
-            pylint --max-positional-arguments=10 '${{github.workspace}}/core'
-          else
-            pylint '${{github.workspace}}/core'
-          fi
+          pylint --max-positional-arguments=10 '${{github.workspace}}/core'

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ import os
 
 from setuptools import setup, find_packages
 
-assert sys.version_info >= (3, 6), "Sorry, Python < 3.6 is not supported."
+assert sys.version_info >= (3, 9), "Sorry, Python < 3.9 is not supported."
 
 
 class InstallPrepare:
@@ -104,7 +104,7 @@ setup(
     entry_points={
         "console_scripts": ["ianvs = core.cmd.benchmarking:main"]
     },
-    python_requires=">=3.6",
+    python_requires=">=3.9",
     long_description=_infos.long_desc,
     long_description_content_type="text/markdown",
     license="Apache License 2.0",


### PR DESCRIPTION
Resolves #693 by updating the CI and project configurations to test against actively supported Python versions and drop those that are End-of-Life (EOL).

Changes included:
1. Updated `.github/workflows/main.yaml` matrix to test Python `3.9`, `3.10`, `3.11`, and `3.12`.
2. Updated `setup.py` `python_requires` to `>=3.9`.
3. Updated `setup.py` runtime assertion to `sys.version_info >= (3, 9)`.
4. Upgraded GitHub Actions `actions/checkout` and `actions/setup-python` to `v4`.
5. Simplified the `pylint` step in CI since all tested Python versions are now >=3.9, which all require the `--max-positional-arguments=10` workaround (originally introduced for 3.9 in #157).
