### PR TITLE
Fix RoboDK Palletizing example: broken config paths, dataset portability, and weight-discovery bug

### DIFF
--- a/examples/RoboDK Palletizing/singletask_learning_bench/benchmarkingjob.yaml
+++ b/examples/RoboDK Palletizing/singletask_learning_bench/benchmarkingjob.yaml
@@ -2,13 +2,13 @@ benchmarkingjob:
   name: "palletizing_bench"
   workspace: "./workspace/palletizing_bench"
 
-  testenv: "/root/ianvs/project/ianvs-0.3.0/examples/Palletizing/singletask_learning_bench/testenv/testenv.yaml"
+  testenv: "./examples/RoboDK Palletizing/singletask_learning_bench/testenv/testenv.yaml"
 
   test_object:
     type: "algorithms"
     algorithms:
       - name: "YOLOv8n"
-        url: "/root/ianvs/project/ianvs-0.3.0/examples/Palletizing/singletask_learning_bench/testalgorithms/algorithm.yaml"
+        url: "./examples/RoboDK Palletizing/singletask_learning_bench/testalgorithms/algorithm.yaml"
 
   rank:
     sort_by:

--- a/examples/RoboDK Palletizing/singletask_learning_bench/readme.md
+++ b/examples/RoboDK Palletizing/singletask_learning_bench/readme.md
@@ -183,8 +183,33 @@ python -m pip install kaggle
 kaggle datasets download kubeedgeianvs/the-robodk-palletizing-dataset
 
 # Unzip the dataset
-unzip RoboDK_Palletizing_Dataset.zip
+unzip the-robodk-palletizing-dataset.zip
 ```
+**Important — dataset path portability:**
+
+Some distributions of the RoboDK Palletizing Dataset contain absolute paths in
+`train_index.txt` and `test_index.txt`
+(e.g. `/root/ianvs/project/data/dataset/RoboDK_Palletizing_Dataset/...`).
+These paths may not match your local environment, causing the example to fail
+to locate dataset files until the index files are converted.
+
+Before running the benchmark, convert the index files to relative paths using
+the helper script included with this example:
+
+```bash
+python ./examples/RoboDK\ Palletizing/singletask_learning_bench/scripts/convert_dataset_indices.py \
+    /path/to/RoboDK_Palletizing_Dataset
+```
+
+This script is idempotent, so it is safe to run even if the paths are already
+relative. Once converted, Ianvs will correctly resolve the dataset relative to
+wherever you placed it (see the `testenv.yaml` configuration below).
+
+Then update `testenv.yaml` so that `train_index` and `test_index` point to
+your local dataset directory.
+
+*A future release of the dataset may ship with portable paths already, making
+this step unnecessary.*
 
 ##### Model Preparation
 

--- a/examples/RoboDK Palletizing/singletask_learning_bench/scripts/convert_dataset_indices.py
+++ b/examples/RoboDK Palletizing/singletask_learning_bench/scripts/convert_dataset_indices.py
@@ -1,0 +1,56 @@
+"""
+Converts the absolute dataset paths in train_index.txt / test_index.txt into
+relative paths, so ianvs's built-in path-resolution logic
+(core/testenvmanager/dataset/dataset.py: _process_txt_index_file) can correctly
+resolve them relative to the index file's own location on any machine.
+
+The RoboDK Palletizing dataset, as currently published on Kaggle, ships with
+absolute paths baked into its index files, e.g.:
+    /root/ianvs/project/data/dataset/RoboDK_Palletizing_Dataset/images/train/...
+This script converts those to relative paths:
+    images/train/...
+which ianvs then resolves relative to wherever the user places the dataset.
+
+This script is idempotent: running it on already-relative index files is a
+safe no-op.
+
+Usage:
+    python convert_dataset_indices.py <path-to-RoboDK_Palletizing_Dataset-folder>
+"""
+import sys
+from pathlib import Path
+
+OLD_PREFIX = "/root/ianvs/project/data/dataset/RoboDK_Palletizing_Dataset/"
+
+
+def convert_index_file(file_path: Path) -> None:
+    content = file_path.read_text(encoding="utf-8")
+    if OLD_PREFIX not in content:
+        print(f"Already portable, no changes needed: {file_path}")
+        return
+    updated = content.replace(OLD_PREFIX, "")
+    file_path.write_text(updated, encoding="utf-8")
+    print(f"Converted to relative paths: {file_path}")
+
+
+def main() -> None:
+    if len(sys.argv) != 2:
+        print("Usage: python convert_dataset_indices.py <path-to-RoboDK_Palletizing_Dataset-folder>")
+        sys.exit(1)
+
+    dataset_dir = Path(sys.argv[1]).resolve()
+
+    if not dataset_dir.is_dir():
+        print(f"Error: {dataset_dir} is not a directory.")
+        sys.exit(1)
+
+    for name in ("train_index.txt", "test_index.txt"):
+        index_file = dataset_dir / name
+        if not index_file.exists():
+            print(f"Warning: {index_file} not found, skipping.")
+            continue
+        convert_index_file(index_file)
+
+
+if __name__ == "__main__":
+    main()

--- a/examples/RoboDK Palletizing/singletask_learning_bench/testalgorithms/algorithm.yaml
+++ b/examples/RoboDK Palletizing/singletask_learning_bench/testalgorithms/algorithm.yaml
@@ -4,7 +4,7 @@ algorithm:
   modules:
     - type: "basemodel"
       name: "YOLOv8n"
-      url: "/root/ianvs/project/ianvs-0.3.0/examples/Palletizing/singletask_learning_bench/testalgorithms/basemodel.py"
+      url: "./examples/RoboDK Palletizing/singletask_learning_bench/testalgorithms/basemodel.py"
       
       hyperparameters:
         - learning_rate:

--- a/examples/RoboDK Palletizing/singletask_learning_bench/testalgorithms/basemodel.py
+++ b/examples/RoboDK Palletizing/singletask_learning_bench/testalgorithms/basemodel.py
@@ -138,9 +138,20 @@ class BaseModel:
             else:
                 raise Exception("Train data must have 'x' (images) and 'y' (labels) attributes")
             
-            train_dirs = list(self.workspace.glob("yolov8_train*"))
+            candidate_dirs = [
+                self.workspace,
+                self.yolo_run_dir / self.workspace.name,
+            ]
+
+            train_dirs = []
+            for directory in candidate_dirs:
+                if directory.exists():
+                    train_dirs = list(directory.glob("yolov8_train*"))
+                    if train_dirs:
+                        break
+
             if not train_dirs:
-                raise FileNotFoundError(f"No training directories found in {self.workspace.absolute()}")
+                raise FileNotFoundError(f"No training directories found in {candidate_dirs}")
     
             latest_train_dir = max(train_dirs, key=lambda d: os.path.getctime(str(d)))
             logging.info(f"[Train]Latest training directory: {latest_train_dir.absolute()}")

--- a/examples/RoboDK Palletizing/singletask_learning_bench/testenv/testenv.yaml
+++ b/examples/RoboDK Palletizing/singletask_learning_bench/testenv/testenv.yaml
@@ -2,16 +2,16 @@ testenv:
   # dataset configuration
   dataset:
     # the url address of train dataset index; string type;
-    train_index: "/root/ianvs/project/data/dataset/RoboDK_Palletizing_Dataset/train_index.txt"
+    train_index: "/path/to/RoboDK_Palletizing_Dataset/train_index.txt"
     # the url address of val dataset index; string type;
-    test_index: "/root/ianvs/project/data/dataset/RoboDK_Palletizing_Dataset/test_index.txt"
+    test_index: "/path/to/RoboDK_Palletizing_Dataset/test_index.txt"
 
   # metrics configuration for test case's evaluation; list type;
   metrics:
       # metric name; string type;
     - name: "map50"
       # the url address of python file
-      url: "/root/ianvs/project/ianvs-0.3.0/examples/Palletizing/singletask_learning_bench/testenv/map50.py"
+      url: "./examples/RoboDK Palletizing/singletask_learning_bench/testenv/map50.py"
     - name: "map90"
       # the url address of python file
-      url: "/root/ianvs/project/ianvs-0.3.0/examples/Palletizing/singletask_learning_bench/testenv/map90.py"
+      url: "./examples/RoboDK Palletizing/singletask_learning_bench/testenv/map90.py"


### PR DESCRIPTION
## What this PR does

Restores the `RoboDK Palletizing` singletask_learning_bench example to a
working state. Previously the example failed immediately due to stale
configuration paths, and even after fixing those, failed again due to the
published dataset's absolute-path index files and a post-training
weight-discovery bug.

## Changes

- **`benchmarkingjob.yaml`, `algorithm.yaml`, `testenv.yaml`**: replaced
  hardcoded, non-existent paths
  (`/root/ianvs/project/ianvs-0.3.0/examples/Palletizing/...`) with correct
  repository-relative paths matching the actual folder name
  (`examples/RoboDK Palletizing/singletask_learning_bench/...`).

- **`scripts/convert_dataset_indices.py`** (new): idempotent utility that
  converts the Kaggle-published dataset's absolute index paths to relative
  ones, so ianvs's existing path-resolution logic can locate the dataset
  regardless of where the user places it or which OS they're on.

- **`testalgorithms/basemodel.py`**: improved post-training weight
  discovery by checking both `self.workspace` and Ultralytics' nested
  output directory (`runs/detect/<workspace-name>`), allowing the example
  to locate the trained weights across the observed output layouts.

- **`readme.md`**: documented the dataset-conversion step, and fixed the
  README's own unzip command to match the actual downloaded filename
  (`the-robodk-palletizing-dataset.zip`, not `RoboDK_Palletizing_Dataset.zip`).

## Verification

Ran the full benchmark end-to-end multiple times on a clean Windows checkout:
1. Downloaded the dataset via the Kaggle API as documented.
2. Ran `convert_dataset_indices.py` to portabilize the index files.
3. Ran `ianvs -f "examples/RoboDK Palletizing/singletask_learning_bench/benchmarkingjob.yaml"`.
4. Confirmed successful training, evaluation, and a populated results table
   (e.g. mAP50 ≈ 0.90 at 2 epochs — reduced epoch count used only for fast
   local verification; `algorithm.yaml` ships with the original 30-epoch
   setting).

## Scope notes

- The dataset's absolute-path packaging issue is tracked separately in
  #695, since the root cause is in the published Kaggle dataset, not this
  repository. `convert_dataset_indices.py` is a compatibility utility for
  that dataset, not a framework change.

## Related

Related to #695.
