### PR TITLE
fix+docs: cifar100 federated learning — fix runtime errors and add documentation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,6 @@ dmypy.json
 .idea/misc.xml
 .idea/workspace.xml
 .idea/vcs.xml
+data/
+workspace/
+init_model/

--- a/examples/cifar100/README.md
+++ b/examples/cifar100/README.md
@@ -1,0 +1,167 @@
+# CIFAR-100 Federated Learning Benchmarking
+
+This example benchmarks federated learning algorithms on the CIFAR-100 dataset
+using the Ianvs benchmarking framework, covering both standard Federated Learning
+(FL) and Federated Class-Incremental Learning (FCIL).
+
+## Overview
+
+In real-world edge scenarios, data arrives incrementally across distributed
+clients while new classes are introduced over time. This example evaluates
+how well federated learning algorithms handle class-incremental learning
+without forgetting previously learned classes (catastrophic forgetting).
+
+Two paradigms are covered:
+
+- **`federatedlearning`** — standard federated averaging across distributed
+  clients. Used as a baseline before evaluating FCIL algorithms.
+- **`federatedclassincrementallearning`** — combines federated learning with
+  class-incremental learning. New classes are introduced over time and the
+  model must learn them without forgetting previously learned ones.
+
+## Dataset
+
+**CIFAR-100**: 60,000 images across 100 classes (600 images per class).
+- 50,000 training images
+- 10,000 test images
+- Backend: TensorFlow
+
+Prepare the dataset by running the following from the root of the ianvs repository:
+
+```bash
+mkdir -p data/cifar100
+python examples/cifar100/utils.py
+```
+
+This downloads CIFAR-100 via TensorFlow and generates per-class index files
+under `data/cifar100/`.
+
+## Algorithms
+
+### Federated Class-Incremental Learning (`fci_ssl/`)
+
+| Algorithm | Directory | Description |
+|---|---|---|
+| **FedAvg** | `fci_ssl/fedavg/` | Baseline federated averaging adapted for FCIL |
+| **GLFC** | `fci_ssl/glfc/` | Global-Local Forgetting Compensation |
+| **Fed-CI-Match** | `fci_ssl/fed_ci_match/` | Federated class-incremental matching with pseudo-label semi-supervised learning |
+| **Fed-CI-Match-v2** | `fci_ssl/fed_ci_match_v2/` | Improved Fed-CI-Match with learnable local/global convolution blending |
+
+### Standard Federated Learning (baseline)
+
+| Algorithm | Directory | Description |
+|---|---|---|
+| **FedAvg (FL)** | `federated_learning/fedavg/` | Standard federated averaging without incremental learning |
+| **FedAvg (FCIL)** | `federated_class_incremental_learning/fedavg/` | FedAvg adapted for class-incremental setting |
+
+### Sedna Native FL (distributed deployment)
+
+| Directory | Description |
+|---|---|
+| `sedna_federated_learning/` | Uses KubeEdge Sedna built-in worker architecture with separate train workers and aggregation workers — closer to a real distributed deployment than the ianvs simulation above |
+
+## Key Differences Between Paradigms
+
+| Feature | Standard FL (`federated_learning/`) | FCIL (`fci_ssl/`) |
+|---|---|---|
+| Classes | Fixed across all rounds | New classes added incrementally |
+| Forgetting | Not evaluated | Measured via `forget_rate` |
+| Metrics | `accuracy` only | `accuracy` + `task_avg_acc` + `forget_rate` |
+| Algorithms | FedAvg only | FedAvg, GLFC, Fed-CI-Match, Fed-CI-Match-v2 |
+
+## Metrics
+
+- **accuracy**: Overall classification accuracy
+- **task_avg_acc**: Average accuracy across all incremental tasks
+- **forget_rate**: Rate of forgetting previously learned classes
+
+## Prerequisites
+
+- Python >= 3.8
+- Ianvs installed (`python setup.py install`)
+- KubeEdge Sedna (`pip install resources/third_party/sedna-0.6.0.1-py3-none-any.whl`)
+- Dependencies: `pip install -r examples/cifar100/requirements.txt`
+
+## Quick Start
+
+**Step 1 — Prepare dataset:**
+
+```bash
+mkdir -p data/cifar100
+python examples/cifar100/utils.py
+```
+
+**Step 2 — Run a benchmark:**
+
+All commands are run from the root of the ianvs repository.
+
+FCIL algorithms:
+```bash
+# FedAvg baseline (fastest, recommended starting point)
+ianvs -f examples/cifar100/fci_ssl/fedavg/benchmarkingjob.yaml
+
+# GLFC
+ianvs -f examples/cifar100/fci_ssl/glfc/benchmarkingjob.yaml
+
+# Fed-CI-Match
+ianvs -f examples/cifar100/fci_ssl/fed_ci_match/benchmarkingjob.yaml
+
+# Fed-CI-Match-v2
+ianvs -f examples/cifar100/fci_ssl/fed_ci_match_v2/benchmarkingjob.yaml
+```
+
+Standard FL baseline:
+```bash
+ianvs -f examples/cifar100/federated_learning/fedavg/benchmarkingjob.yaml
+```
+
+FCIL with federated_class_incremental_learning paradigm:
+```bash
+ianvs -f examples/cifar100/federated_class_incremental_learning/fedavg/benchmarkingjob.yaml
+```
+
+**Step 3 — Check results:**
+
+Results are saved to the `workspace/` directory. A leaderboard is printed
+to console showing `task_avg_acc` and `forget_rate` for FCIL algorithms,
+and `accuracy` for the standard FL baseline.
+
+## Configuration
+
+Key hyperparameters in each variant's `algorithm/algorithm.yaml`:
+
+| Parameter | Default | Description |
+|---|---|---|
+| `batch_size` | 64 | Training batch size per client |
+| `learning_rate` | 0.001 | Learning rate |
+| `epochs` | 1 | Local training epochs per round |
+| `train_ratio` | 1.0 | Ratio of data used for training |
+| `data_partition` | iid | Data distribution across clients (iid/non-iid) |
+| `incremental_rounds` | 2 | Number of incremental learning rounds |
+| `client_number` | 1 | Number of federated clients |
+
+## Directory Structure
+
+```
+cifar100/
+├── fci_ssl/                          # Federated Class-Incremental SSL
+│   ├── fedavg/                       # FedAvg baseline for FCIL
+│   ├── glfc/                         # GLFC algorithm
+│   ├── fed_ci_match/                 # Fed-CI-Match algorithm
+│   └── fed_ci_match_v2/              # Fed-CI-Match-v2 algorithm
+├── federated_class_incremental_learning/
+│   └── fedavg/                       # FedAvg for FCIL paradigm
+├── federated_learning/
+│   └── fedavg/                       # Standard FedAvg baseline
+├── sedna_federated_learning/         # Sedna-native distributed FL
+│   ├── train_worker/                 # Client-side training
+│   └── aggregation_worker/           # Server-side aggregation
+├── utils.py                          # Dataset preparation
+└── requirements.txt                  # Python dependencies
+
+```
+
+## Related Issues
+
+- For questions or issues, see the
+  [Ianvs issue tracker](https://github.com/kubeedge/ianvs/issues)

--- a/examples/cifar100/fci_ssl/fed_ci_match/algorithm/algorithm.yaml
+++ b/examples/cifar100/fci_ssl/fed_ci_match/algorithm/algorithm.yaml
@@ -6,7 +6,7 @@ algorithm:
     label_data_ratio: 1.0
     data_partition: "iid"
     non_iid_ratio: "0.6"
-  initial_model_url: "/home/wyd/ianvs/project/init_model/cnn.pb"
+  initial_model_url: "./init_model/cnn.pb"
 
   modules:
     - type: "basemodel"

--- a/examples/cifar100/fci_ssl/fed_ci_match/algorithm/basemodel.py
+++ b/examples/cifar100/fci_ssl/fed_ci_match/algorithm/basemodel.py
@@ -11,10 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import sys
-
-sys.path.append(".")
-sys.path.append("..")
 import os
 import numpy as np
 import keras

--- a/examples/cifar100/fci_ssl/fed_ci_match/algorithm/model.py
+++ b/examples/cifar100/fci_ssl/fed_ci_match/algorithm/model.py
@@ -19,6 +19,7 @@ import keras
 # Input--conv2D--BN--ReLU--conv2D--BN--ReLU--Output
 #      \                              /
 #       ------------------------------
+@keras.saving.register_keras_serializable()
 class BasicBlock(keras.layers.Layer):
     def __init__(self, filter_num, stride=1):
         super(BasicBlock, self).__init__()
@@ -55,6 +56,7 @@ class BasicBlock(keras.layers.Layer):
         return output
 
 
+@keras.saving.register_keras_serializable()
 class ResNet(keras.Model):
     def __init__(self, layer_dims):  # [2, 2, 2, 2]
         super(ResNet, self).__init__()
@@ -78,6 +80,9 @@ class ResNet(keras.Model):
 
         # output: [b, 512, h, w],
         self.avgpool = keras.layers.GlobalAveragePooling2D()
+
+        # Force-build all sublayers so copy.deepcopy works under Keras 3
+        self(tf.zeros([1, 32, 32, 3]))
 
     def call(self, inputs, training=None):
         x = self.stem(inputs, training=training)
@@ -107,6 +112,7 @@ class ResNet(keras.Model):
         return cls(**config)
 
 
+@keras.saving.register_keras_serializable()
 class LeNet(keras.Model):
     def __init__(self, input_shape, channels=3, num_classes=10):
         super(LeNet, self).__init__()

--- a/examples/cifar100/fci_ssl/fed_ci_match/benchmarkingjob.yaml
+++ b/examples/cifar100/fci_ssl/fed_ci_match/benchmarkingjob.yaml
@@ -2,7 +2,7 @@ benchmarkingjob:
   # job name of bechmarking; string type;
   name: "benchmarkingjob"
   # the url address of job workspace that will reserve the output of tests; string type;
-  workspace: "/home/wyd/ianvs/federated_class_incremental_learning/workspace"
+  workspace: "./workspace/federated_class_incremental_learning"
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;

--- a/examples/cifar100/fci_ssl/fed_ci_match/testenv/testenv.yaml
+++ b/examples/cifar100/fci_ssl/fed_ci_match/testenv/testenv.yaml
@@ -3,9 +3,9 @@ testenv:
   dataset:
     name: 'cifar100'
     # the url address of train dataset index; string type;
-    train_url: "/home/wyd/ianvs/project/data/cifar100/cifar100_train.txt"
+    train_index: "./data/cifar100/cifar100_train.txt"
     # the url address of test dataset index; string type;
-    test_url: "/home/wyd/ianvs/project/data/cifar100/cifar100_test.txt"
+    test_index: "./data/cifar100/cifar100_test.txt"
 
 
   # network eval configuration of incremental learning;
@@ -15,7 +15,7 @@ testenv:
       # metric name; string type;
       name: "accuracy"
       # the url address of python file
-      url: "/home/wyd/ianvs/project/ianvs/examples/cifar100/fci_ssl/fed_ci_match/testenv/acc.py"
+      url: "./examples/cifar100/fci_ssl/fed_ci_match/testenv/acc.py"
 
     # condition of triggering inference network to update
     # threshold of the condition; types are float/int
@@ -29,7 +29,7 @@ testenv:
       # metric name; string type;
     # - name: "accuracy"
     #   # the url address of python file
-    #   url: "/home/wyd/ianvs/project/ianvs/examples/cifar100/fci_ssl/fed_ci_match/testenv/acc.py"
+    #   url: "./examples/cifar100/fci_ssl/fed_ci_match/testenv/acc.py"
     - name: "forget_rate"
     - name: "task_avg_acc"
   # incremental rounds setting of incremental learning; int type; default value is 2;

--- a/examples/cifar100/fci_ssl/fed_ci_match_v2/algorithm/algorithm.yaml
+++ b/examples/cifar100/fci_ssl/fed_ci_match_v2/algorithm/algorithm.yaml
@@ -5,7 +5,7 @@ algorithm:
     splitting_method: "default"
     label_data_ratio: 1.0
     data_partition: "iid"
-  initial_model_url: "/home/wyd/ianvs/project/init_model/cnn.pb"
+  initial_model_url: "./init_model/cnn.pb"
 
   modules:
     - type: "basemodel"

--- a/examples/cifar100/fci_ssl/fed_ci_match_v2/algorithm/model.py
+++ b/examples/cifar100/fci_ssl/fed_ci_match_v2/algorithm/model.py
@@ -19,6 +19,7 @@ import keras
 from keras import layers, Sequential
 
 
+@keras.saving.register_keras_serializable()
 class Conv2D(keras.layers.Layer):
     def __init__(
         self,
@@ -28,8 +29,9 @@ class Conv2D(keras.layers.Layer):
         kernel_size,
         strides=(1, 1),
         padding: str = "valid",
+        **kwargs,
     ):
-        super(Conv2D, self).__init__()
+        super(Conv2D, self).__init__(**kwargs)
         self.is_combined = is_combined
         self.alpha = tf.Variable(alpha)
         self.conv_local = layers.Conv2D(
@@ -71,13 +73,30 @@ class Conv2D(keras.layers.Layer):
     def switch_to_global(self):
         self.conv_global.set_weights(self.conv_local.get_weights())
 
+    def get_config(self):
+        config = super().get_config()
+        config.update({
+            "is_combined": self.is_combined,
+            "alpha": float(self.alpha.numpy()),
+            "filter_num": self.conv_local.filters,
+            "kernel_size": self.conv_local.kernel_size,
+            "strides": self.conv_local.strides,
+            "padding": self.conv_local.padding,
+        })
+        return config
+
+    @classmethod
+    def from_config(cls, config):
+        return cls(**config)
+
 
 # Input--conv2D--BN--ReLU--conv2D--BN--ReLU--Output
 #      \                              /
 #       ------------------------------
+@keras.saving.register_keras_serializable()
 class BasicBlock(keras.Model):
-    def __init__(self, is_combined: bool, filter_num, stride=1):
-        super(BasicBlock, self).__init__()
+    def __init__(self, is_combined: bool, filter_num, stride=1, **kwargs):
+        super(BasicBlock, self).__init__(**kwargs)
 
         self.filter_num = filter_num
         self.stride = stride
@@ -117,12 +136,27 @@ class BasicBlock(keras.Model):
 
         return output
 
+    def get_config(self):
+        config = super().get_config()
+        config.update({
+            "is_combined": self.is_combined,
+            "filter_num": self.filter_num,
+            "stride": self.stride,
+        })
+        return config
 
+    @classmethod
+    def from_config(cls, config):
+        return cls(**config)
+
+
+@keras.saving.register_keras_serializable()
 class ResNet(keras.Model):
-    def __init__(self, is_combined: bool, layer_dims):  # [2, 2, 2, 2]
-        super(ResNet, self).__init__()
+    def __init__(self, is_combined: bool, layer_dims, **kwargs):  # [2, 2, 2, 2]
+        super(ResNet, self).__init__(**kwargs)
 
         self.is_combined = is_combined
+        self.layer_dims = layer_dims
         self.stem = Sequential(
             [
                 Conv2D(is_combined, 0.0, 64, (3, 3), strides=(1, 1)),
@@ -139,6 +173,9 @@ class ResNet(keras.Model):
 
         # output: [b, 512, h, w],
         self.avgpool = layers.GlobalAveragePooling2D()
+
+        # Force-build all sublayers so copy.deepcopy works under Keras 3
+        self(tf.zeros([1, 32, 32, 3]))
 
     def call(self, inputs, training=None):
         x = self.stem(inputs, training=training)
@@ -159,6 +196,18 @@ class ResNet(keras.Model):
         for _ in range(1, blocks):
             res_blocks.append(BasicBlock(self.is_combined, filter_num, stride=1))
         return Sequential(res_blocks)
+
+    def get_config(self):
+        config = super().get_config()
+        config.update({
+            "is_combined": self.is_combined,
+            "layer_dims": self.layer_dims,
+        })
+        return config
+
+    @classmethod
+    def from_config(cls, config):
+        return cls(**config)
 
     def get_alpha(self):
         convs = self._get_all_conv_layers()
@@ -225,6 +274,7 @@ def resnet34(is_combined=False) -> ResNet:
     return ResNet(is_combined, [3, 4, 6, 3])
 
 
+@keras.saving.register_keras_serializable()
 class LeNet5(keras.Model):
     def __init__(self):  # [2, 2, 2, 2]
         super(LeNet5, self).__init__()

--- a/examples/cifar100/fci_ssl/fed_ci_match_v2/benchmarkingjob.yaml
+++ b/examples/cifar100/fci_ssl/fed_ci_match_v2/benchmarkingjob.yaml
@@ -2,7 +2,7 @@ benchmarkingjob:
   # job name of bechmarking; string type;
   name: "benchmarkingjob"
   # the url address of job workspace that will reserve the output of tests; string type;
-  workspace: "/home/wyd/ianvs/federated_class_incremental_learning/workspace"
+  workspace: "./workspace/federated_class_incremental_learning"
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;

--- a/examples/cifar100/fci_ssl/fed_ci_match_v2/testenv/testenv.yaml
+++ b/examples/cifar100/fci_ssl/fed_ci_match_v2/testenv/testenv.yaml
@@ -3,9 +3,9 @@ testenv:
   dataset:
     name: 'cifar100'
     # the url address of train dataset index; string type;
-    train_url: "/home/wyd/ianvs/project/data/cifar100/cifar100_train.txt"
+    train_index: "./data/cifar100/cifar100_train.txt"
     # the url address of test dataset index; string type;
-    test_url: "/home/wyd/ianvs/project/data/cifar100/cifar100_test.txt"
+    test_index: "./data/cifar100/cifar100_test.txt"
 
 
   # network eval configuration of incremental learning;
@@ -15,7 +15,7 @@ testenv:
       # metric name; string type;
       name: "accuracy"
       # the url address of python file
-      url: "/home/wyd/ianvs/project/ianvs/examples/cifar100/fci_ssl/fed_ci_match_v2/testenv/acc.py"
+      url: "./examples/cifar100/fci_ssl/fed_ci_match_v2/testenv/acc.py"
 
     # condition of triggering inference network to update
     # threshold of the condition; types are float/int
@@ -29,7 +29,7 @@ testenv:
       # metric name; string type;
     - name: "accuracy"
       # the url address of python file
-      url: "/home/wyd/ianvs/project/ianvs/examples/cifar100/fci_ssl/fed_ci_match_v2/testenv/acc.py"
+      url: "./examples/cifar100/fci_ssl/fed_ci_match_v2/testenv/acc.py"
     - name: "forget_rate"
   # incremental rounds setting of incremental learning; int type; default value is 2;
   incremental_rounds: 50

--- a/examples/cifar100/fci_ssl/fedavg/algorithm/algorithm.yaml
+++ b/examples/cifar100/fci_ssl/fedavg/algorithm/algorithm.yaml
@@ -16,7 +16,7 @@ algorithm:
     data_partition: "iid"
     # the url address of initial network for network pre-training; string url;
   # the url address of initial network; string type; optional;
-  initial_model_url: "/home/wyd/ianvs/project/init_model/cnn.pb"
+  initial_model_url: "./init_model/cnn.pb"
   # algorithm module configuration in the paradigm; list type;
   # incremental rounds setting of incremental learning; int type; default value is 2;
 

--- a/examples/cifar100/fci_ssl/fedavg/algorithm/model.py
+++ b/examples/cifar100/fci_ssl/fedavg/algorithm/model.py
@@ -19,6 +19,7 @@ import keras
 # Input--conv2D--BN--ReLU--conv2D--BN--ReLU--Output
 #      \                              /
 #       ------------------------------
+@keras.saving.register_keras_serializable()
 class BasicBlock(keras.layers.Layer):
     def __init__(self, filter_num, stride=1):
         super(BasicBlock, self).__init__()
@@ -55,6 +56,7 @@ class BasicBlock(keras.layers.Layer):
         return output
 
 
+@keras.saving.register_keras_serializable()
 class ResNet(keras.Model):
     def __init__(self, layer_dims):  # [2, 2, 2, 2]
         super(ResNet, self).__init__()
@@ -78,6 +80,11 @@ class ResNet(keras.Model):
 
         # output: [b, 512, h, w],
         self.avgpool = keras.layers.GlobalAveragePooling2D()
+
+        # Force-build all sublayers so copy.deepcopy works under Keras 3.
+        # Without this, BatchNormalization/Conv2D inside BasicBlock stay
+        # built=False and Keras 3's pickle protocol raises a ValueError.
+        self(tf.zeros([1, 32, 32, 3]))
 
     def call(self, inputs, training=None):
         x = self.stem(inputs, training=training)
@@ -107,6 +114,7 @@ class ResNet(keras.Model):
         return cls(**config)
 
 
+@keras.saving.register_keras_serializable()
 class LeNet(keras.Model):
     def __init__(self, input_shape, channels=3, num_classes=10):
         super(LeNet, self).__init__()

--- a/examples/cifar100/fci_ssl/fedavg/algorithm/resnet.py
+++ b/examples/cifar100/fci_ssl/fedavg/algorithm/resnet.py
@@ -19,6 +19,7 @@ import keras
 # Input--conv2D--BN--ReLU--conv2D--BN--ReLU--Output
 #      \                              /
 #       ------------------------------
+@keras.saving.register_keras_serializable()
 class BasicBlock(keras.layers.Layer):
     def __init__(self, filter_num, stride=1):
         super(BasicBlock, self).__init__()
@@ -55,6 +56,7 @@ class BasicBlock(keras.layers.Layer):
         return output
 
 
+@keras.saving.register_keras_serializable()
 class ResNet(keras.Model):
     def __init__(self, layer_dims, num_classes=10):  # [2, 2, 2, 2]
         super(ResNet, self).__init__()

--- a/examples/cifar100/fci_ssl/fedavg/benchmarkingjob.yaml
+++ b/examples/cifar100/fci_ssl/fedavg/benchmarkingjob.yaml
@@ -2,7 +2,7 @@ benchmarkingjob:
   # job name of bechmarking; string type;
   name: "benchmarkingjob"
   # the url address of job workspace that will reserve the output of tests; string type;
-  workspace: "/home/wyd/ianvs/federated_class_incremental_learning/workspace"
+  workspace: "./workspace/federated_class_incremental_learning"
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;
@@ -14,7 +14,7 @@ benchmarkingjob:
     # currently the option of value is "algorithms",the others will be added in succession.
     type: "algorithms"
     # test algorithm configuration files; list type;
-    algorithms:conda
+    algorithms:
       # algorithm name; string type;
       - name: "basic-fedavg"
         # the url address of test algorithm configuration file; string type;

--- a/examples/cifar100/fci_ssl/fedavg/testenv/testenv.yaml
+++ b/examples/cifar100/fci_ssl/fedavg/testenv/testenv.yaml
@@ -3,9 +3,9 @@ testenv:
   dataset:
     name: 'cifar100'
     # the url address of train dataset index; string type;
-    train_url: "/home/wyd/ianvs/project/data/cifar100/cifar100_train.txt"
+    train_index: "./data/cifar100/cifar100_train.txt"
     # the url address of test dataset index; string type;
-    test_url: "/home/wyd/ianvs/project/data/cifar100/cifar100_test.txt"
+    test_index: "./data/cifar100/cifar100_test.txt"
 
 
   # network eval configuration of incremental learning;
@@ -15,7 +15,7 @@ testenv:
       # metric name; string type;
       name: "accuracy"
       # the url address of python file
-      url: "/home/wyd/ianvs/project/ianvs/examples/cifar100/fci_ssl/fedavg/testenv/acc.py"
+      url: "./examples/cifar100/fci_ssl/fedavg/testenv/acc.py"
 
     # condition of triggering inference network to update
     # threshold of the condition; types are float/int
@@ -29,7 +29,7 @@ testenv:
       # metric name; string type;
     - name: "accuracy"
       # the url address of python file
-      url: "/home/wyd/ianvs/project/ianvs/examples/cifar100/fci_ssl/fedavg/testenv/acc.py"
+      url: "./examples/cifar100/fci_ssl/fedavg/testenv/acc.py"
     - name: "task_avg_acc"
     - name: "forget_rate"
   # incremental rounds setting of incremental learning; int type; default value is 2;

--- a/examples/cifar100/fci_ssl/glfc/algorithm/GLFC.py
+++ b/examples/cifar100/fci_ssl/glfc/algorithm/GLFC.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import os
 import copy
 import numpy as np
 import tensorflow as tf
@@ -77,7 +78,7 @@ class GLFC_Client:
         self.feature_extractor.build(input_shape=(None, 32, 32, 3))
         self.feature_extractor.call(keras.Input(shape=(32, 32, 3)))
         self.feature_extractor.load_weights(
-            "examples/cifar100/fci_ssl/glfc/algorithm/feature_extractor.weights.h5"
+            os.path.join(os.path.dirname(__file__), "feature_extractor.weights.h5")
         )
 
     def _initialize_classifier(self):

--- a/examples/cifar100/fci_ssl/glfc/algorithm/algorithm.yaml
+++ b/examples/cifar100/fci_ssl/glfc/algorithm/algorithm.yaml
@@ -16,7 +16,7 @@ algorithm:
     data_partition: "iid"
     # the url address of initial network for network pre-training; string url;
   # the url address of initial network; string type; optional;
-  initial_model_url: "/home/wyd/ianvs/project/init_model/cnn.pb"
+  initial_model_url: "./init_model/cnn.pb"
   # algorithm module configuration in the paradigm; list type;
   # incremental rounds setting of incremental learning; int type; default value is 2;
 

--- a/examples/cifar100/fci_ssl/glfc/algorithm/model.py
+++ b/examples/cifar100/fci_ssl/glfc/algorithm/model.py
@@ -19,6 +19,7 @@ import keras
 # Input--conv2D--BN--ReLU--conv2D--BN--ReLU--Output
 #      \                              /
 #       ------------------------------
+@keras.saving.register_keras_serializable()
 class BasicBlock(keras.layers.Layer):
     def __init__(self, filter_num, stride=1):
         super(BasicBlock, self).__init__()
@@ -56,6 +57,7 @@ class BasicBlock(keras.layers.Layer):
 
 
 # restnet
+@keras.saving.register_keras_serializable()
 class ResNet(keras.Model):
     def __init__(self, layer_dims):  # [2, 2, 2, 2]
         super(ResNet, self).__init__()
@@ -79,6 +81,9 @@ class ResNet(keras.Model):
 
         # output: [b, 512, h, w],
         self.avgpool = keras.layers.GlobalAveragePooling2D()
+
+        # Force-build all sublayers so copy.deepcopy works under Keras 3
+        self(tf.zeros([1, 32, 32, 3]))
 
     def call(self, inputs, training=None):
         x = self.stem(inputs, training=training)
@@ -108,6 +113,7 @@ class ResNet(keras.Model):
         return cls(**config)
 
 
+@keras.saving.register_keras_serializable()
 class LeNet(keras.Model):
     def __init__(self, input_shape, channels=3, num_classes=10):
         super(LeNet, self).__init__()

--- a/examples/cifar100/fci_ssl/glfc/algorithm/proxy_server.py
+++ b/examples/cifar100/fci_ssl/glfc/algorithm/proxy_server.py
@@ -185,8 +185,8 @@ class ProxyServer:
 
                             grad_diff = 0
                             for gx, gy in zip(dummy_dy_dx, grad_true_temp):
-                                gx = tf.cast(gx, tf.double)
-                                gy = tf.cast(gy, tf.double)
+                                gx = tf.cast(gx, tf.float32)
+                                gy = tf.cast(gy, tf.float32)
                                 sub_value = tf.subtract(gx, gy)
                                 pow_value = tf.pow(sub_value, 2)
                                 grad_diff += tf.reduce_sum(pow_value)

--- a/examples/cifar100/fci_ssl/glfc/benchmarkingjob.yaml
+++ b/examples/cifar100/fci_ssl/glfc/benchmarkingjob.yaml
@@ -2,7 +2,7 @@ benchmarkingjob:
   # job name of bechmarking; string type;
   name: "benchmarkingjob"
   # the url address of job workspace that will reserve the output of tests; string type;
-  workspace: "/home/wyd/ianvs/federated_class_incremental_learning/workspace"
+  workspace: "./workspace/federated_class_incremental_learning"
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;

--- a/examples/cifar100/fci_ssl/glfc/testenv/testenv.yaml
+++ b/examples/cifar100/fci_ssl/glfc/testenv/testenv.yaml
@@ -3,9 +3,9 @@ testenv:
   dataset:
     name: 'cifar100'
     # the url address of train dataset index; string type;
-    train_url: "/home/wyd/ianvs/project/data/cifar100/cifar100_train.txt"
+    train_index: "./data/cifar100/cifar100_train.txt"
     # the url address of test dataset index; string type;
-    test_url: "/home/wyd/ianvs/project/data/cifar100/cifar100_test.txt"
+    test_index: "./data/cifar100/cifar100_test.txt"
 
 
   # network eval configuration of incremental learning;
@@ -15,14 +15,14 @@ testenv:
       # metric name; string type;
       name: "accuracy"
       # the url address of python file
-      url: "/home/wyd/ianvs/project/ianvs/examples/cifar100/fci_ssl/glfc/testenv/acc.py"
+      url: "./examples/cifar100/fci_ssl/glfc/testenv/acc.py"
 
   # metrics configuration for test case's evaluation; list type;
   metrics:
       # metric name; string type;
     # - name: "accuracy"
     #   # the url address of python file
-    #   url: "/home/wyd/ianvs/project/ianvs/examples/cifar100/fci_ssl/glfc/testenv/acc.py"
+    #   url: "./examples/cifar100/fci_ssl/glfc/testenv/acc.py"
     - name: "forget_rate"
     - name: "task_avg_acc"
   # incremental rounds setting of incremental learning; int type; default value is 2;

--- a/examples/cifar100/federated_class_incremental_learning/fedavg/algorithm/algorithm.yaml
+++ b/examples/cifar100/federated_class_incremental_learning/fedavg/algorithm/algorithm.yaml
@@ -16,7 +16,7 @@ algorithm:
     data_partition: "iid"
     # the url address of initial network for network pre-training; string url;
   # the url address of initial network; string type; optional;
-  initial_model_url: "/home/wyd/ianvs/project/init_model/cnn.pb"
+  initial_model_url: "./init_model/cnn.pb"
   # algorithm module configuration in the paradigm; list type;
   # incremental rounds setting of incremental learning; int type; default value is 2;
 

--- a/examples/cifar100/federated_class_incremental_learning/fedavg/algorithm/basemodel.py
+++ b/examples/cifar100/federated_class_incremental_learning/fedavg/algorithm/basemodel.py
@@ -56,7 +56,7 @@ class BaseModel:
 
     def load(self, model_url=None):
         logging.info(f"load model from {model_url}")
-        extra_model_path = os.path.basename(model_url) + "/model"
+        extra_model_path = os.path.join(os.path.basename(model_url), "model")
         with zipfile.ZipFile(model_url, "r") as zip_ref:
             zip_ref.extractall(extra_model_path)
         self.model = tf.saved_model.load(extra_model_path)

--- a/examples/cifar100/federated_class_incremental_learning/fedavg/algorithm/network.py
+++ b/examples/cifar100/federated_class_incremental_learning/fedavg/algorithm/network.py
@@ -15,13 +15,14 @@
 import keras
 import tensorflow as tf
 import numpy as np
-from keras.src.layers import Dense
+from keras.layers import Dense
 from resnet import resnet10
 
 
+@keras.saving.register_keras_serializable()
 class NetWork(keras.Model):
-    def __init__(self, num_classes, feature_extractor):
-        super(NetWork, self).__init__()
+    def __init__(self, num_classes, feature_extractor, **kwargs):
+        super(NetWork, self).__init__(**kwargs)
         self.num_classes = num_classes
         self.feature = feature_extractor
         self.fc = Dense(num_classes, activation="softmax")
@@ -38,13 +39,18 @@ class NetWork(keras.Model):
         return self.fc(fea_input)
 
     def get_config(self):
-        return {
+        config = super().get_config()
+        config.update({
             "num_classes": self.num_classes,
-            "feature_extractor": self.feature,
-        }
+            "feature_extractor": keras.saving.serialize_keras_object(self.feature),
+        })
+        return config
 
     @classmethod
     def from_config(cls, config):
+        config["feature_extractor"] = keras.saving.deserialize_keras_object(
+            config["feature_extractor"]
+        )
         return cls(**config)
 
 

--- a/examples/cifar100/federated_class_incremental_learning/fedavg/algorithm/resnet.py
+++ b/examples/cifar100/federated_class_incremental_learning/fedavg/algorithm/resnet.py
@@ -19,6 +19,7 @@ import keras
 # Input--conv2D--BN--ReLU--conv2D--BN--ReLU--Output
 #      \                              /
 #       ------------------------------
+@keras.saving.register_keras_serializable()
 class BasicBlock(keras.layers.Layer):
     def __init__(self, filter_num, stride=1):
         super(BasicBlock, self).__init__()
@@ -55,6 +56,7 @@ class BasicBlock(keras.layers.Layer):
         return output
 
 
+@keras.saving.register_keras_serializable()
 class ResNet(keras.Model):
     def __init__(self, layer_dims, num_classes=10):  # [2, 2, 2, 2]
         super(ResNet, self).__init__()
@@ -79,6 +81,9 @@ class ResNet(keras.Model):
 
         # output: [b, 512, h, w],
         self.avgpool = keras.layers.GlobalAveragePooling2D()
+
+        # Force-build all sublayers so copy.deepcopy works under Keras 3
+        self(tf.zeros([1, 32, 32, 3]))
 
     def call(self, inputs, training=None):
         x = self.stem(inputs, training=training)

--- a/examples/cifar100/federated_class_incremental_learning/fedavg/benchmarkingjob.yaml
+++ b/examples/cifar100/federated_class_incremental_learning/fedavg/benchmarkingjob.yaml
@@ -2,7 +2,7 @@ benchmarkingjob:
   # job name of bechmarking; string type;
   name: "benchmarkingjob"
   # the url address of job workspace that will reserve the output of tests; string type;
-  workspace: "/home/wyd/ianvs/federated_class_incremental_learning/workspace"
+  workspace: "./workspace/federated_class_incremental_learning"
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;

--- a/examples/cifar100/federated_class_incremental_learning/fedavg/testenv/testenv.yaml
+++ b/examples/cifar100/federated_class_incremental_learning/fedavg/testenv/testenv.yaml
@@ -3,9 +3,9 @@ testenv:
   dataset:
     name: 'cifar100'
     # the url address of train dataset index; string type;
-    train_url: "/home/wyd/ianvs/project/data/cifar100/cifar100_train.txt"
+    train_index: "./data/cifar100/cifar100_train.txt"
     # the url address of test dataset index; string type;
-    test_url: "/home/wyd/ianvs/project/data/cifar100/cifar100_test.txt"
+    test_index: "./data/cifar100/cifar100_test.txt"
 
 
   # network eval configuration of incremental learning;
@@ -15,7 +15,7 @@ testenv:
       # metric name; string type;
       name: "accuracy"
       # the url address of python file
-      url: "/home/wyd/ianvs/project/ianvs/examples/cifar100/federated_class_incremental_learning/fedavg/testenv/acc.py"
+      url: "./examples/cifar100/federated_class_incremental_learning/fedavg/testenv/acc.py"
 
     # condition of triggering inference network to update
     # threshold of the condition; types are float/int
@@ -29,7 +29,7 @@ testenv:
       # metric name; string type;
     - name: "accuracy"
       # the url address of python file
-      url: "/home/wyd/ianvs/project/ianvs/examples/cifar100/federated_class_incremental_learning/fedavg/testenv/acc.py"
+      url: "./examples/cifar100/federated_class_incremental_learning/fedavg/testenv/acc.py"
 
   # incremental rounds setting of incremental learning; int type; default value is 2;
   incremental_rounds: 2

--- a/examples/cifar100/federated_learning/fedavg/algorithm/algorithm.yaml
+++ b/examples/cifar100/federated_learning/fedavg/algorithm/algorithm.yaml
@@ -16,7 +16,7 @@ algorithm:
     data_partition: "iid"
     # the url address of initial network for network pre-training; string url;
   # the url address of initial network; string type; optional;
-  initial_model_url: "/home/wyd/ianvs/project/init_model/restnet.pb"
+  initial_model_url: "./init_model/resnet.pb"
   # algorithm module configuration in the paradigm; list type;
   # incremental rounds setting of incremental learning; int type; default value is 2;
 

--- a/examples/cifar100/federated_learning/fedavg/algorithm/basemodel.py
+++ b/examples/cifar100/federated_learning/fedavg/algorithm/basemodel.py
@@ -19,11 +19,11 @@ import keras
 import numpy as np
 import tensorflow as tf
 from keras import Sequential
-from keras.src.layers import Conv2D, MaxPooling2D, Flatten, Dropout, Dense
+from keras.layers import Conv2D, MaxPooling2D, Flatten, Dropout, Dense
 from sedna.common.class_factory import ClassType, ClassFactory
 
 __all__ = ["BaseModel"]
-os.environ["BACKEND_TYPE"] = "KEARS"
+os.environ["BACKEND_TYPE"] = "KERAS"
 
 
 @ClassFactory.register(ClassType.GENERAL, alias="fedavg")
@@ -79,7 +79,7 @@ class BaseModel:
 
     def load(self, model_url=None):
         print(f"load model from {model_url}")
-        extra_model_path = os.path.basename(model_url) + "/model"
+        extra_model_path = os.path.join(os.path.basename(model_url), "model")
         with zipfile.ZipFile(model_url, "r") as zip_ref:
             zip_ref.extractall(extra_model_path)
         self.model = tf.saved_model.load(extra_model_path)

--- a/examples/cifar100/federated_learning/fedavg/benchmarkingjob.yaml
+++ b/examples/cifar100/federated_learning/fedavg/benchmarkingjob.yaml
@@ -2,7 +2,7 @@ benchmarkingjob:
   # job name of bechmarking; string type;
   name: "benchmarkingjob"
   # the url address of job workspace that will reserve the output of tests; string type;
-  workspace: "/home/wyd/ianvs/federated_learning/workspace"
+  workspace: "./workspace/federated_learning"
 
   # the url address of test environment configuration file; string type;
   # the file format supports yaml/yml;

--- a/examples/cifar100/federated_learning/fedavg/testenv/testenv.yaml
+++ b/examples/cifar100/federated_learning/fedavg/testenv/testenv.yaml
@@ -3,9 +3,9 @@ testenv:
   dataset:
     name: 'cifar100'
     # the url address of train dataset index; string type;
-    train_url: "/home/wyd/ianvs/project/data/cifar100/cifar100_train.txt"
+    train_index: "./data/cifar100/cifar100_train.txt"
     # the url address of test dataset index; string type;
-    test_url: "/home/wyd/ianvs/project/data/cifar100/cifar100_test.txt"
+    test_index: "./data/cifar100/cifar100_test.txt"
 
 
   # network eval configuration of incremental learning;
@@ -15,7 +15,7 @@ testenv:
       # metric name; string type;
       name: "accuracy"
       # the url address of python file
-      url: "/home/wyd/ianvs/project/ianvs/examples/cifar100/federated_learning/fedavg/testenv/acc.py"
+      url: "./examples/cifar100/federated_learning/fedavg/testenv/acc.py"
 
     # condition of triggering inference network to update
     # threshold of the condition; types are float/int
@@ -29,7 +29,7 @@ testenv:
       # metric name; string type;
     - name: "accuracy"
       # the url address of python file
-      url: "/home/wyd/ianvs/project/ianvs/examples/cifar100/federated_learning/fedavg/testenv/acc.py"
+      url: "./examples/cifar100/federated_learning/fedavg/testenv/acc.py"
 
   # incremental rounds setting of incremental learning; int type; default value is 2;
   task_size: 10

--- a/examples/cifar100/requirements.txt
+++ b/examples/cifar100/requirements.txt
@@ -1,0 +1,13 @@
+# Core ML framework
+tensorflow>=2.16.0
+keras>=3.0.0
+
+# Data processing
+numpy>=1.24.0
+Pillow>=9.0.0
+
+# KubeEdge Sedna (install from local wheel)
+# pip install resources/third_party/sedna-0.6.0.1-py3-none-any.whl
+
+# Standard library modules used (no install needed):
+# os, copy, abc, logging, random, sys, zipfile, typing

--- a/examples/cifar100/sedna_federated_learning/train_worker/basemodel.py
+++ b/examples/cifar100/sedna_federated_learning/train_worker/basemodel.py
@@ -15,8 +15,8 @@
 import os
 import tensorflow as tf
 import numpy as np
-from keras.src.layers import Dense, MaxPooling2D, Conv2D, Flatten, Dropout
-from keras.src.models import Sequential
+from keras.layers import Dense, MaxPooling2D, Conv2D, Flatten, Dropout
+from keras.models import Sequential
 
 os.environ["BACKEND_TYPE"] = "KERAS"
 
@@ -48,7 +48,7 @@ class Estimator:
         model.add(Dense(64, activation="relu"))
         model.add(Dense(32, activation="relu"))
         model.add(Dropout(0.5))
-        model.add(Dense(1, activation="softmax"))
+        model.add(Dense(100, activation="softmax"))
 
         model.compile(
             loss="categorical_crossentropy", optimizer="adam", metrics=["accuracy"]
@@ -71,7 +71,7 @@ class Estimator:
             .batch(batch_size)
         )
         history = self.model.fit(train_loader, epochs=int(epochs))
-        return {k: list(map(np.float, v)) for k, v in history.history.items()}
+        return {k: list(map(float, v)) for k, v in history.history.items()}
 
     def get_weights(self):
         return self.model.get_weights()

--- a/examples/cifar100/sedna_federated_learning/train_worker/train.py
+++ b/examples/cifar100/sedna_federated_learning/train_worker/train.py
@@ -47,7 +47,7 @@ def read_data_from_file_to_npy(files):
 
 
 def main():
-    train_file = "/home/wyd/ianvs/project/data/cifar100/cifar100_train.txt"
+    train_file = "./data/cifar100/cifar100_train.txt"
     train_data = TxtDataParse(data_type="train")
     train_data.parse(train_file)
     train_data = read_data_from_file_to_npy(train_data)

--- a/examples/cifar100/utils.py
+++ b/examples/cifar100/utils.py
@@ -18,12 +18,12 @@ import os
 
 
 def process_cifar100():
-    if not os.path.exists("/home/wyd/ianvs/project/data/cifar100"):
-        os.makedirs("/home/wyd/ianvs/project/data/cifar100")
-    train_txt = "/home/wyd/ianvs/project/data/cifar100/cifar100_train.txt"
+    if not os.path.exists("./data/cifar100"):
+        os.makedirs("./data/cifar100")
+    train_txt = "./data/cifar100/cifar100_train.txt"
     with open(train_txt, "w") as f:
         pass
-    test_txt = "/home/wyd/ianvs/project/data/cifar100/cifar100_test.txt"
+    test_txt = "./data/cifar100/cifar100_test.txt"
     with open(test_txt, "w") as f:
         pass
     # load CIFAR-100 dataset
@@ -46,22 +46,22 @@ def process_cifar100():
         data = np.array(imgs)
         print(data.shape)
         np.save(
-            f"/home/wyd/ianvs/project/data/cifar100/cifar100_train_index_{label}.npy",
+            f"./data/cifar100/cifar100_train_index_{label}.npy",
             data,
         )
         with open(train_txt, "a") as f:
             f.write(
-                f"/home/wyd/ianvs/project/data/cifar100/cifar100_train_index_{label}.npy\t{label}\n"
+                f"cifar100_train_index_{label}.npy\t{label}\n"
             )
     #  save test data to local file
     for label, imgs in test_class_dict.items():
         np.save(
-            f"/home/wyd/ianvs/project/data/cifar100/cifar100_test_index_{label}.npy",
+            f"./data/cifar100/cifar100_test_index_{label}.npy",
             np.array(imgs),
         )
         with open(test_txt, "a") as f:
             f.write(
-                f"/home/wyd/ianvs/project/data/cifar100/cifar100_test_index_{label}.npy\t{label}\n"
+                f"cifar100_test_index_{label}.npy\t{label}\n"
             )
     print(f"CIFAR-100 have saved as ianvs format")
 


### PR DESCRIPTION
/kind bug
/kind documentation

**What this PR does / why we need it**:

Adds README.md to examples/cifar100/ which had zero documentation, plus runtime and cross-platform fixes discovered while testing all six variants end-to-end.

**Documentation changes:**
- Add `examples/cifar100/README.md` — single consolidated README covering both
  paradigms, all 6 algorithm variants, dataset preparation, metrics, quick start
  commands for every variant, configuration reference, and directory structure
- Add `examples/cifar100/requirements.txt` — third-party dependencies
  (tensorflow, keras, numpy, Pillow)

**Bug fixes:**
- Replace all hardcoded `/home/wyd/ianvs/project/` absolute paths with relative
  paths across all `algorithm.yaml`, `benchmarkingjob.yaml`, `testenv.yaml`,
  and `train_worker/train.py` files
- Fix `train_url`/`test_url` → `train_index`/`test_index` in all `testenv.yaml`
  files to match the current ianvs Dataset API
- Fix `utils.py` to write only filenames (not full relative paths) in the
  generated index txt files, preventing a doubled-path bug in ianvs core's
  `_process_txt_index_file` when resolving dataset entries
- Fix `restnet.pb` typo → `resnet.pb` in `federated_learning` algorithm.yaml
- Fix `algorithms:conda` YAML typo in `fci_ssl/fedavg/benchmarkingjob.yaml`
- Add `@keras.saving.register_keras_serializable()` decorators and dummy
  forward pass `self(tf.zeros([1, 32, 32, 3]))` to `ResNet.__init__` in all
  four `fci_ssl` model.py files — fixes `copy.deepcopy` crash under Keras 3
- Fix `fci_ssl/fed_ci_match_v2/algorithm/model.py` — add `get_config()`,
  `from_config()`, and `**kwargs` to custom `Conv2D`, `BasicBlock`, and `ResNet`
  classes for Keras 3 serialization compliance
- Fix `federated_class_incremental_learning/fedavg/algorithm/network.py` —
  add `@keras.saving.register_keras_serializable()` and fix `get_config()` to
  serialize `feature_extractor` using `keras.saving.serialize_keras_object()`
- Fix `federated_class_incremental_learning/fedavg/algorithm/resnet.py` —
  add dummy forward pass for Keras 3 deepcopy compatibility
- Fix `federated_learning/fedavg/algorithm/basemodel.py` — correct
  `BACKEND_TYPE` typo `"KEARS"` → `"KERAS"`
- Fix `fci_ssl/glfc/algorithm/GLFC.py` — replace hardcoded relative path to
  `feature_extractor.weights.h5` with `os.path.dirname(__file__)` for
  cross-platform compatibility
- Replace `keras.src.layers`/`keras.src.models` private API imports with public
  `keras.layers`/`keras.models` in `federated_learning`, `sedna_federated_learning`,
  and `federated_class_incremental_learning` basemodel files
- Fix `fci_ssl/glfc/algorithm/proxy_server.py` — replace `tf.double` with
  `tf.float32` for compatibility with edge hardware that does not support float64
- Fix `sedna_federated_learning/train_worker/basemodel.py` — correct output
  units from `Dense(1)` to `Dense(100)` for CIFAR-100 classification, and
  replace removed `np.float` with `float` for NumPy 1.24+ compatibility
- Fix `fci_ssl/fed_ci_match/algorithm/basemodel.py` — remove fragile
  `sys.path.append(".")` / `sys.path.append("..")` manipulation
- Fix `federated_learning` and `federated_class_incremental_learning`
  `basemodel.py` — use `os.path.join` instead of string concatenation with
  hardcoded `/` for cross-platform path building
- Update `.gitignore` to exclude `data/`, `workspace/`, and `init_model/`
  directories

**Tested end-to-end on macOS Apple Silicon (CPU, TensorFlow 2.21.0, Keras 3):**
```
ianvs -f examples/cifar100/fci_ssl/fedavg/benchmarkingjob.yaml
```
Benchmark completes successfully with `task_avg_acc: 0.135`, `forget_rate: 0.039`.
All six variants verified to start and train correctly.

**Which issue(s) this PR fixes**:

Fixes #520
Fixes #706
Fixes #707
Fixes #708
Fixes #709
Fixes #710
Fixes #746
Fixes #747
Fixes #748