### PR TITLE
Fix typo in README.md (detetion → detection)

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,13 @@ Follow the [Ianvs installation document](docs/guides/how-to-install-ianvs.md) to
 
   - Example PCB-AoI-2：[Testing incremental learning in industrial defect detection](docs/proposals/test-reports/testing-incremental-learning-in-industrial-defect-detection-with-pcb-aoi.md).
 
-- Scenario Cityscapes-Synthia: [Curb Detetion on Cityscapes-Synthia Dataset](docs/proposals/algorithms/lifelong-learning/Additional-documentation/curb_detetion_datasets.md)
+- Scenario Cityscapes-Synthia: [Curb Detection on Cityscapes-Synthia Dataset](docs/proposals/algorithms/lifelong-learning/Additional-documentation/curb_detetion_datasets.md)
 
   - Example Cityscapes-Synthia-1: [Lifelong learning in semantic segmentation](examples/cityscapes-synthia/lifelong_learning_bench/semantic-segmentation/README.md)
 
-  - Example Cityscapes-Synthia-2: [Lifelong learning in curb detetion](examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/README.md)
+  - Example Cityscapes-Synthia-2: [Lifelong learning in curb detection](examples/cityscapes-synthia/lifelong_learning_bench/curb-detection/README.md)
 
-  - Example Cityscapes-Synthia-3: [Scene based unknown task recognition in curb detetion](examples/cityscapes-synthia/scene-based-unknown-task-recognition/curb-detection/README.md)
+  - Example Cityscapes-Synthia-3: [Scene based unknown task recognition in curb detection](examples/cityscapes-synthia/scene-based-unknown-task-recognition/curb-detection/README.md)
 
   - Example Cityscapes-Synthia-4: [Integrating GAN and Self-taught Learning into Ianvs Lifelong Learning](examples/cityscapes/lifelong_learning_bench/unseen_task_processing-GANwithSelfTaughtLearning/README.md)
 

--- a/docs/proposals/algorithms/lifelong-learning/Additional-documentation/Testing_Open-set_recognition_in_Curb-detection_datasets.md
+++ b/docs/proposals/algorithms/lifelong-learning/Additional-documentation/Testing_Open-set_recognition_in_Curb-detection_datasets.md
@@ -14,7 +14,7 @@ See [here](https://github.com/Frank-lilinjie/ianvs/tree/main/docs/proposals/algo
 
 Two datasets, SYNTHIA, and cityscape, were selected for this project. Because SYNTHIA is often easier to obtain than the real urban road dataset as simulated by the simulator in a real research environment, it is treated as known task data for model pre-training, while the real urban landscape image acquisition requires more resources and is more difficult to obtain, so it is treated as unknown task data.
 
-See [here](https://github.com/Frank-lilinjie/ianvs/tree/main/docs/proposals/algorithms/lifelong-learning/Additional-documentation/curb_detetion_datasets.md) for details
+See [here](https://github.com/Frank-lilinjie/ianvs/tree/main/docs/proposals/algorithms/lifelong-learning/Additional-documentation/curb_detection_datasets.md) for details
 
 
 

--- a/docs/proposals/algorithms/lifelong-learning/Implementation of a Class Incremental Learning Algorithm Evaluation System based on Ianvs.md
+++ b/docs/proposals/algorithms/lifelong-learning/Implementation of a Class Incremental Learning Algorithm Evaluation System based on Ianvs.md
@@ -97,7 +97,7 @@ All in all, we use the three class-different datasets to conduct training (i.e.,
 
 This project will use three datasets, namely **Cityscapes**, **SYNTHIA**, and KubeEdge SIG AI's **Cloud-Robotics** dataset (**CS**, **SYN**, **CR**).
 
-Ianvs has already provides [Cityscapes and SYNTHIA datasets](https://github.com/kubeedge/ianvs/blob/main/docs/proposals/algorithms/lifelong-learning/Additional-documentation/curb_detetion_datasets.md). The following two images are examples from them respectively.
+Ianvs has already provides [Cityscapes and SYNTHIA datasets](https://github.com/kubeedge/ianvs/blob/main/docs/proposals/algorithms/lifelong-learning/Additional-documentation/curb_detection_datasets.md). The following two images are examples from them respectively.
 
 |                          CS Example                          |                         SYN Example                          |
 | :----------------------------------------------------------: | :----------------------------------------------------------: |

--- a/docs/proposals/algorithms/lifelong-learning/Unknown_Task_Recognition_Algorithm_Reproduction_based_on_Lifelong_Learning_of_Ianvs.md
+++ b/docs/proposals/algorithms/lifelong-learning/Unknown_Task_Recognition_Algorithm_Reproduction_based_on_Lifelong_Learning_of_Ianvs.md
@@ -153,7 +153,7 @@ Usage Process
 
 Two datasets, SYNTHIA, and cityscape, were selected for this project. Because SYNTHIA is often easier to obtain than the real urban road dataset as simulated by the simulator in a real research environment, it is treated as known task data for model pre-training, while the real urban landscape image acquisition requires more resources and is more difficult to obtain, so it is treated as unknown task data.
 
-You can check [here](https://github.com/Frank-lilinjie/ianvs/tree/main/docs/proposals/algorithms/lifelong-learning/Additional-documentation/curb_detetion_datasets.md) for more details about curb_detetion_datasets.
+You can check [here](https://github.com/Frank-lilinjie/ianvs/tree/main/docs/proposals/algorithms/lifelong-learning/Additional-documentation/curb_detection_datasets.md) for more details about curb_detetion_datasets.
 
 ## 5 Design Details
 


### PR DESCRIPTION
Corrected spelling mistake “detetion” → “detection” in README.md.