### PR TITLE
fix: create output directory before saving heatmap

### DIFF
--- a/core/storymanager/visualization/visualization.py
+++ b/core/storymanager/visualization/visualization.py
@@ -39,9 +39,12 @@ def draw_heatmap_picture(output, title, matrix):
     plt.ylabel('task', fontsize=15)
     plt.title(title, fontsize=15)
     plt.colorbar(format='%.2f')
-    output_dir = os.path.join(output, f"output/{title}-heatmap.png")
-    plt.savefig(output_dir)
+    output_dir = os.path.join(output, "output")
+    os.makedirs(output_dir, exist_ok=True)
+    output_file = os.path.join(output_dir, f"{title}-heatmap.png")
+    plt.savefig(output_file)
     plt.show()
+    plt.close()
 
 def get_visualization_func(mode):
     """ get visualization func """


### PR DESCRIPTION
## What

`draw_heatmap_picture()` passed a path under `<output>/output/` directly to
`plt.savefig()`, which does not create parent directories. On a fresh run
directory this raised `FileNotFoundError` and aborted the benchmark before
any results were rendered.

## Changes

- Create the target directory with `os.makedirs(..., exist_ok=True)` before saving
- Build the path with `os.path.join` instead of an embedded `/`, so it behaves
  correctly on Windows as well as Linux
- `plt.close()` after saving, so repeated calls don't leak figures

## Testing

- Reproduced the crash against a temporary directory with no `output/`
  subdirectory and confirmed `FileNotFoundError`
- Confirmed the patched version writes `<output>/output/<title>-heatmap.png`

Fixes #628
