### PR TITLE
[PHASE IV] fix(core): honour use_gpu: false and apply gpu visibility before modu…

### DIFF
--- a/core/testcasecontroller/algorithm/paradigm/base.py
+++ b/core/testcasecontroller/algorithm/paradigm/base.py
@@ -53,8 +53,26 @@ class ParadigmBase:
         self.dataset = kwargs.get("dataset")
         self.workspace = workspace
         self.system_metric_info = {}
+        # note: this must be applied before _get_module_instances(), which imports
+        # and instantiates the algorithm module, because AI frameworks read
+        # CUDA_VISIBLE_DEVICES when they initialize their device list.
+        self._set_gpu_visibility(kwargs.get("use_gpu"))
         self.module_instances = self._get_module_instances()
         os.environ["LOCAL_TEST"] = "TRUE"
+
+    @classmethod
+    def _set_gpu_visibility(cls, use_gpu):
+        if use_gpu is None:
+            # use_gpu is not configured in testenv: leave the gpu visibility of
+            # the environment as it is, which is the behaviour ianvs has always had.
+            return
+
+        if use_gpu:
+            os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+        else:
+            # "-1" instead of "" because an empty value is read back as unset by
+            # some AI frameworks, which then fall back to using every device.
+            os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
 
     def dataset_output_dir(self):
         """

--- a/core/testcasecontroller/algorithm/paradigm/singletask_learning/singletask_learning.py
+++ b/core/testcasecontroller/algorithm/paradigm/singletask_learning/singletask_learning.py
@@ -52,8 +52,6 @@ class SingleTaskLearning(ParadigmBase):
         self.mode = kwargs.get("mode")
         self.quantization_type = kwargs.get("quantization_type")
         self.llama_quantize_path = kwargs.get("llama_quantize_path")
-        if kwargs.get("use_gpu", True):
-            os.environ["CUDA_VISIBLE_DEVICES"] = "0"
 
     def run(self):
         """

--- a/core/testenvmanager/testenv/testenv.py
+++ b/core/testenvmanager/testenv/testenv.py
@@ -46,7 +46,9 @@ class TestEnv:
         self.round = 1
         self.client_number = 1
         self.dataset = None
-        self.use_gpu = False  # default false
+        # None means not configured, in which case ianvs does not touch the gpu
+        # visibility of the environment. Set it to false to force a cpu-only run.
+        self.use_gpu = None
         self._parse_config(config)
 
     def _check_fields(self):


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`use_gpu` is declared on `TestEnv` and parsed from `testenv.yaml`, but it was read in exactly one place — `SingleTaskLearning.__init__`:

```python
if kwargs.get("use_gpu", True):
    os.environ["CUDA_VISIBLE_DEVICES"] = "0"
```

That produced two defects:

1. **`use_gpu: false` was a silent no-op.** No `else` branch, so a CPU-configured run inherited the host's `CUDA_VISIBLE_DEVICES` and took the GPU anyway. `examples/llm-edge-benchmark-suite/single_task_bench_with_compression` ships `use_gpu: false` and never got its CPU-only run.
2. **`use_gpu: true` was applied too late.** `ParadigmBase.__init__` runs first (line 50) and calls `_get_module_instances()`, which imports and instantiates the user's `basemodel.py` — where AI frameworks get imported and pick their device. The assignment landed six lines later, after the model already existed.

`use_gpu` was also honoured only by `singletasklearning`, despite living on the shared `TestEnv`.

**The change**

Moved the policy into `ParadigmBase.__init__`, immediately before `_get_module_instances()`:

- fixes the ordering by construction — the variable is set before any algorithm module is imported;
- applies to every paradigm rather than only `singletasklearning`;
- `use_gpu: false` now sets `CUDA_VISIBLE_DEVICES=-1`.

`-1` rather than `""`, because an empty value is read back as unset by some frameworks, which then fall back to using every device. The repo still ships TF1-era examples, so the more portable value is worth preferring.

**Why `TestEnv.use_gpu` now defaults to `None` — the part worth reviewing closely**

`TestEnv` declared `use_gpu = False`, but the *effective* behaviour for a testenv omitting the key was "do not touch `CUDA_VISIBLE_DEVICES`", because the only consumer's fallback was `kwargs.get("use_gpu", True)`. Declared default and real behaviour contradicted each other.

Only 2 of ~45 examples declare `use_gpu`. Honouring the declared `False` literally would have forced every other example onto CPU — a silent, repo-wide regression. I hit exactly this with a first version of the patch and backed it out.

So the default is now `None`, meaning "not configured, inherit the environment", giving three states:

| testenv | `CUDA_VISIBLE_DEVICES` | changed? |
|---|---|---|
| key absent | untouched | no — identical to today |
| `use_gpu: false` | `-1` | **yes — this is the fix** |
| `use_gpu: true` | `0` | same value as today, applied earlier |

This is safe because `_parse_config` normalises any present key through `bool(v)`, so `None` can only ever mean "absent from the yaml".

**Testing**

Verified with a `singletasklearning` job whose base model prints `CUDA_VISIBLE_DEVICES` at `__init__`, `train` and `predict`, run with `CUDA_VISIBLE_DEVICES=0,1,2,3` in the environment. Before/after for all three testenv states:

| testenv | before | after |
|---|---|---|
| key absent | `0,1,2,3` at every stage | `0,1,2,3` at every stage — unchanged |
| `use_gpu: false` | `0,1,2,3` at every stage | `-1` at every stage |
| `use_gpu: true` | `0,1,2,3` at `__init__`, then `0` | `0` at every stage |

`pylint --max-positional-arguments=10 core` stays at 10.00/10.

**Not addressed here**, to keep this focused — happy to open follow-ups:

- `TestEnv._parse_config` uses `bool(v)`, so a quoted `use_gpu: "false"` evaluates to `True`.
- With `use_gpu: true`, an operator's existing `CUDA_VISIBLE_DEVICES=2` is still overwritten with `0`. Arguably it should be respected, but that is a behaviour change beyond this fix.

**Which issue(s) this PR fixes**:

Fixes #765
