### PR TITLE
fix: handle quasi identifiers in hard sample mining

### DIFF
--- a/examples/TAB/cloud_edge_collaborative_inference_bench/test_algorithms/hard_sample_mining/hard_sample_mining.py
+++ b/examples/TAB/cloud_edge_collaborative_inference_bench/test_algorithms/hard_sample_mining/hard_sample_mining.py
@@ -75,7 +75,7 @@ class OracleRouter:
         for ent in sensitive_entities or []:
             if not isinstance(ent, dict):
                 continue
-            if ent.get("identifier_type") == "DIRECT" or ent.get("dentifier_type") == "QUASI":
+            if ent.get("identifier_type") == "DIRECT" or ent.get("identifier_type") == "QUASI":
                 start = int(ent.get("start_offset", 0) or 0)
                 end = int(ent.get("end_offset", 0) or 0)
                 entity_type = ent.get("entity_type", "UNKNOWN")


### PR DESCRIPTION
## What does this PR do?

Fixes a typo in the QUASI identifier check in the hard sample mining
algorithm.

The code was checking `dentifier_type` instead of `identifier_type`,
which caused QUASI sensitive entities to be skipped when building the
answer text.

## What was changed?

Changed:

`ent.get("dentifier_type")`

to:

`ent.get("identifier_type")`

## Validation

- `python -m py_compile` passed
- Python AST syntax check passed
- `git diff --check` passed
- Verified a QUASI entity is transformed correctly:
  `Alice lives in Paris` → `Alice lives in LOC`