### PR TITLE
ci(ianvs): run pytest in github actions

### DIFF
--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -27,7 +27,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install libgl1-mesa-glx -y
           python -m pip install pip==24.0
-          python -m pip install  pylint
+          python -m pip install pylint "pytest<8"
           python -m pip install ${{github.workspace}}/resources/third_party/*
           python -m pip install -r ${{github.workspace}}/requirements.txt
       - name: Analysing code of core with pylint
@@ -38,4 +38,11 @@ jobs:
             pylint --max-positional-arguments=10 '${{github.workspace}}/core'
           else
             pylint '${{github.workspace}}/core'
+          fi
+      - name: Run pytest
+        run: |
+          if [ -d "tests" ]; then
+            PYTHONPATH=. python -m pytest tests
+          else
+            echo "tests/ directory not found. Skipping pytest."
           fi


### PR DESCRIPTION
**What type of PR is this?**

/kind test


**What this PR does / why we need it**:

This PR integrates pytest execution into the existing GitHub Actions CI workflow.

Previously, CI only performed pylint checks and did not execute the pytest-based unit tests introduced in the repository.

Changes:
- Added `pytest` to CI-only tool installation.
- Added a pytest execution step in `.github/workflows/main.yaml`.
- The workflow safely skips pytest when the `tests/` directory is not available, allowing compatibility with the current branch state while tests are introduced.

Running tests automatically helps detect regressions earlier and improves confidence in future contributions.


**Which issue(s) this PR fixes**:

Fixes #814 