### PR TITLE
fix(storymanager): correct save_mode validation in rank.py

### DIFF
--- a/core/storymanager/rank/rank.py
+++ b/core/storymanager/rank/rank.py
@@ -276,13 +276,18 @@ class Rank:
             self._save_all()
             self._save_selected(test_cases, test_results)
 
-        if self.save_mode == "selected_only":
+        elif self.save_mode == "selected_only":
             self._save_selected(test_cases, test_results)
 
-        if self.save_mode == "selected_and_all_and_picture":
+        elif self.save_mode == "selected_and_all_and_picture":
             self._save_all()
             self._save_selected(test_cases, test_results)
             self._draw_pictures(test_cases, test_results)
+
+        else:
+            raise ValueError(
+                f"rank's save_mode({self.save_mode}) is not supported by save()."
+            )
 
     def plot(self):
         """

--- a/core/storymanager/rank/rank.py
+++ b/core/storymanager/rank/rank.py
@@ -85,10 +85,10 @@ class Rank:
         if not self.selected_dataitem.get("metrics"):
             raise ValueError("not found metrics of selected_dataitem in rank.")
 
-        if not self.save_mode and not isinstance(self.save_mode, list):
+        valid_save_modes = ("selected_and_all", "selected_only", "selected_and_all_and_picture")
+        if not isinstance(self.save_mode, str) or self.save_mode not in valid_save_modes:
             raise ValueError(
-                f"rank's save_mode({self.save_mode}) "
-                f"must be provided and be list type."
+                f"rank's save_mode({self.save_mode}) must be one of {valid_save_modes}."
             )
 
     @classmethod

--- a/core/testcasecontroller/algorithm/paradigm/singletask_learning/singletask_learning_active_boost.py
+++ b/core/testcasecontroller/algorithm/paradigm/singletask_learning/singletask_learning_active_boost.py
@@ -48,8 +48,8 @@ class SingleTaskLearningACBoost(SingleTaskLearning):
         # Load test set data
         img_prefix = self.dataset.image_folder_url
         ann_file_path = self.dataset.test_url
-        with open(ann_file_path, mode="r", encoding="utf-8") as f:
-            ann_file = json.load(f)
+        with open(ann_file_path, mode="r", encoding="utf-8") as file_handle:
+            ann_file = json.load(file_handle)
         test_set = []
         for i in ann_file['images']:
             test_set.append(os.path.join(img_prefix, i['file_name']))

--- a/core/testcasecontroller/algorithm/paradigm/singletask_learning/singletask_learning_active_boost.py
+++ b/core/testcasecontroller/algorithm/paradigm/singletask_learning/singletask_learning_active_boost.py
@@ -48,7 +48,8 @@ class SingleTaskLearningACBoost(SingleTaskLearning):
         # Load test set data
         img_prefix = self.dataset.image_folder_url
         ann_file_path = self.dataset.test_url
-        ann_file = json.load(open(ann_file_path, mode="r", encoding="utf-8"))
+        with open(ann_file_path, mode="r", encoding="utf-8") as f:
+            ann_file = json.load(f)
         test_set = []
         for i in ann_file['images']:
             test_set.append(os.path.join(img_prefix, i['file_name']))

--- a/core/testcasecontroller/algorithm/paradigm/singletask_learning/singletask_learning_tta.py
+++ b/core/testcasecontroller/algorithm/paradigm/singletask_learning/singletask_learning_tta.py
@@ -45,8 +45,8 @@ class SingleTaskLearningTTA(SingleTaskLearning):
         # Load test set data
         img_prefix = self.dataset.image_folder_url
         ann_file_path = self.dataset.test_url
-        with open(ann_file_path, mode="r", encoding="utf-8") as f:
-            ann_file = json.load(f)
+        with open(ann_file_path, mode="r", encoding="utf-8") as file_handle:
+            ann_file = json.load(file_handle)
         test_set = []
         for i in ann_file['images']:
             test_set.append(os.path.join(img_prefix, i['file_name']))

--- a/core/testcasecontroller/algorithm/paradigm/singletask_learning/singletask_learning_tta.py
+++ b/core/testcasecontroller/algorithm/paradigm/singletask_learning/singletask_learning_tta.py
@@ -45,7 +45,8 @@ class SingleTaskLearningTTA(SingleTaskLearning):
         # Load test set data
         img_prefix = self.dataset.image_folder_url
         ann_file_path = self.dataset.test_url
-        ann_file = json.load(open(ann_file_path, mode="r", encoding="utf-8"))
+        with open(ann_file_path, mode="r", encoding="utf-8") as f:
+            ann_file = json.load(f)
         test_set = []
         for i in ann_file['images']:
             test_set.append(os.path.join(img_prefix, i['file_name']))

--- a/examples/industrialEI/pose-estimation-llio/testalgorithms/llio_fusion/utils.py
+++ b/examples/industrialEI/pose-estimation-llio/testalgorithms/llio_fusion/utils.py
@@ -7,8 +7,20 @@ from functools import wraps
 import time
 from core.common.log import LOGGER
 
-MATPLOTLIB_AVAILABLE = False
-OPEN3D_AVAILABLE = False
+try:
+    import matplotlib
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Ellipse
+    from matplotlib.collections import PatchCollection
+    MATPLOTLIB_AVAILABLE = True
+except ImportError:
+    MATPLOTLIB_AVAILABLE = False
+
+try:
+    import open3d as o3d
+    OPEN3D_AVAILABLE = True
+except ImportError:
+    OPEN3D_AVAILABLE = False
 
 
 def timeit(func):


### PR DESCRIPTION
Fixes #828

**What this PR does / why we need it**:

`save_mode` validation in `core/storymanager/rank/rank.py` has two bugs that cause silent failures:

1. Wrong type check — `isinstance(self.save_mode, list)` but `save_mode` is always a string
2. Wrong operator — `and` instead of `or` means a typo'd string value like `"selcted_only"` makes `not self.save_mode` false, short-circuiting the entire check with no exception raised

Net effect: a typo in `save_mode` in `benchmarkingjob.yaml` causes Ianvs to run the full benchmark and then silently produce no leaderboard output — no CSV, no error message, just an empty output directory.

**Fix**:

```python
valid_save_modes = ("selected_and_all", "selected_only", "selected_and_all_and_picture")
if not isinstance(self.save_mode, str) or self.save_mode not in valid_save_modes:
    raise ValueError(
        f"rank's save_mode({self.save_mode}) must be one of {valid_save_modes}."
    )
```

This validates against the correct type and the exact set of accepted values, so unsupported values fail loudly at config-parse time instead of silently at save time.

**Which issue(s) this PR fixes**:
Fixes #828