### PR TITLE
ci: add GitHub Actions workflow for example lint and requirements validation

### DIFF
--- a/.github/workflows/example-lint.yml
+++ b/.github/workflows/example-lint.yml
@@ -1,0 +1,59 @@
+name: Example Lint
+
+on:
+  pull_request:
+    paths:
+      - 'examples/**'
+
+jobs:
+  example-pylint:
+    runs-on: ubuntu-22.04
+    name: pylint
+    strategy:
+      matrix:
+        python-version: [ "3.9", "3.10", "3.11" ]
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v3
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install libgl1-mesa-glx -y
+          python -m pip install pip==24.0
+          python -m pip install pylint
+          python -m pip install ${{github.workspace}}/resources/third_party/*
+          python -m pip install -r ${{github.workspace}}/requirements.txt
+      - name: Analysing example code with pylint
+        # `--max-positional-arguments=10` is set for Python 3.9 to avoid `R0917: too-many-positional-arguments`.
+        # See details at https://github.com/kubeedge/ianvs/issues/157
+        run: |
+          if [ "${{ matrix.python-version }}" = "3.9" ]; then
+            pylint --max-positional-arguments=10 '${{github.workspace}}/examples'
+          else
+            pylint '${{github.workspace}}/examples'
+          fi
+
+  requirements-check:
+    runs-on: ubuntu-22.04
+    name: requirements.txt presence check
+    steps:
+      - uses: actions/checkout@v3
+      - name: Check each example with benchmarkingjob.yaml has requirements.txt
+        run: |
+          missing=0
+          while IFS= read -r -d '' job_file; do
+            example_dir=$(dirname "$job_file")
+            if [ ! -f "$example_dir/requirements.txt" ]; then
+              echo "::error file=$job_file::Missing requirements.txt in $example_dir"
+              missing=1
+            fi
+          done < <(find "${{ github.workspace }}/examples" -name "benchmarkingjob.yaml" -print0)
+
+          if [ "$missing" -eq 1 ]; then
+            echo "One or more example directories with a benchmarkingjob.yaml are missing a requirements.txt."
+            exit 1
+          fi
+          echo "All example directories with benchmarkingjob.yaml have requirements.txt."

--- a/.github/workflows/example-lint.yml
+++ b/.github/workflows/example-lint.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
     paths:
       - 'examples/**'
+      - 'core/**'
+      - 'requirements.txt'
 
 jobs:
   example-pylint:
@@ -13,9 +15,9 @@ jobs:
       matrix:
         python-version: [ "3.9", "3.10", "3.11" ]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v3
+        uses: actions/setup-python@v7
         with:
           python-version: ${{ matrix.python-version }}
       - name: Install dependencies
@@ -32,6 +34,7 @@ jobs:
         # continue-on-error: the examples/ backlog is not pylint-clean yet, so this check
         # is currently advisory only. Remove continue-on-error once examples reach a
         # baseline passing state, so this becomes a real PR-blocking gate.
+        # Tracked in kubeedge/ianvs#995.
         continue-on-error: true
         run: |
           if [ "${{ matrix.python-version }}" = "3.9" ]; then
@@ -44,12 +47,13 @@ jobs:
     runs-on: ubuntu-22.04
     name: requirements.txt presence check
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v7
       - name: Check each example with benchmarkingjob.yaml has requirements.txt
         # continue-on-error: most of the examples/ backlog is still missing a
         # requirements.txt, so this check is currently advisory only. Remove
         # continue-on-error once examples reach a baseline passing state, so
         # this becomes a real PR-blocking gate.
+        # Tracked in kubeedge/ianvs#995.
         continue-on-error: true
         run: |
           missing=0

--- a/.github/workflows/example-lint.yml
+++ b/.github/workflows/example-lint.yml
@@ -29,6 +29,10 @@ jobs:
       - name: Analysing example code with pylint
         # `--max-positional-arguments=10` is set for Python 3.9 to avoid `R0917: too-many-positional-arguments`.
         # See details at https://github.com/kubeedge/ianvs/issues/157
+        # continue-on-error: the examples/ backlog is not pylint-clean yet, so this check
+        # is currently advisory only. Remove continue-on-error once examples reach a
+        # baseline passing state, so this becomes a real PR-blocking gate.
+        continue-on-error: true
         run: |
           if [ "${{ matrix.python-version }}" = "3.9" ]; then
             pylint --max-positional-arguments=10 '${{github.workspace}}/examples'
@@ -42,6 +46,11 @@ jobs:
     steps:
       - uses: actions/checkout@v3
       - name: Check each example with benchmarkingjob.yaml has requirements.txt
+        # continue-on-error: most of the examples/ backlog is still missing a
+        # requirements.txt, so this check is currently advisory only. Remove
+        # continue-on-error once examples reach a baseline passing state, so
+        # this becomes a real PR-blocking gate.
+        continue-on-error: true
         run: |
           missing=0
           while IFS= read -r -d '' job_file; do

--- a/examples/industrialEI/pose-estimation-llio/testalgorithms/llio_fusion/utils.py
+++ b/examples/industrialEI/pose-estimation-llio/testalgorithms/llio_fusion/utils.py
@@ -7,8 +7,20 @@ from functools import wraps
 import time
 from core.common.log import LOGGER
 
-MATPLOTLIB_AVAILABLE = False
-OPEN3D_AVAILABLE = False
+try:
+    import matplotlib
+    import matplotlib.pyplot as plt
+    from matplotlib.patches import Ellipse
+    from matplotlib.collections import PatchCollection
+    MATPLOTLIB_AVAILABLE = True
+except ImportError:
+    MATPLOTLIB_AVAILABLE = False
+
+try:
+    import open3d as o3d
+    OPEN3D_AVAILABLE = True
+except ImportError:
+    OPEN3D_AVAILABLE = False
 
 
 def timeit(func):


### PR DESCRIPTION
/kind feature

**What this PR does / why we need it**:

Adds `.github/workflows/example-lint.yml` — a CI workflow that runs on every PR touching `examples/` and validates:

1. **Pylint across example Python files** — matrix tested on Python 3.9, 3.10, 3.11
2. **Requirements check** — verifies every example directory with a `benchmarkingjob.yaml` also has a `requirements.txt`

Follows the same conventions as the existing `.github/workflows/main.yaml` — pinned pip, `resources/third_party` wheel install, root `requirements.txt`, and the `--max-positional-arguments=10` Python 3.9 workaround from #157.

**Current status — advisory only (continue-on-error: true)**:

Both the pylint and requirements-check steps are currently non-blocking. From the examples audit: only 13/29 example directories have a `requirements.txt`, and the example code hasn't been pylint-cleaned yet. A hard-blocking gate on the full tree would block PRs for pre-existing violations unrelated to the change being reviewed.

The workflow is designed to become blocking incrementally as:
- Example requirements.txt coverage improves (tracked via the dependency manifest fixes)
- Example pylint violations are cleared (tracked via the example restoration PRs)

This approach aligns with the tiered validation strategy in the Phase IV CI proposal (PR #541).

**Which issue(s) this PR fixes**:
Related to #846