### PR TITLE
docs: fix §6.3 config contract YAML — correct block key and leaf key names

### DIFF
--- a/docs/proposals/simulation/sandbox-engine/sandbox-engine.md
+++ b/docs/proposals/simulation/sandbox-engine/sandbox-engine.md
@@ -133,6 +133,10 @@ When `sandbox_profile` is absent, execution falls through to `testcase.run(works
 
 ### 6.3 Configuration contract (opt-in)
 
+The cluster simulation is configured under the existing `simulation:` key,
+parsed by `BenchmarkingJob._parse_simulation_config()` into `self.simulation`.
+The `sandbox_profile:` key (new, this proposal) coexists with it:
+
 ```yaml
 benchmarkingjob:
   name: "llm-edge-evaluation"
@@ -141,9 +145,15 @@ benchmarkingjob:
   sandbox_profile:
     enabled: true
     system_metrics: ["cpu_utilization", "peak_memory_mb", "wall_time_s"]
-  cluster_simulation:
-    cloud_nodes: 1
-    edge_nodes: 2
+  # EXISTING key — parsed by BenchmarkingJob._parse_simulation_config()
+  # into self.simulation and consumed by build_simulation_environment().
+  # Keys: cloud_number, edge_number, cluster_name, kubeedge_version, sedna_version.
+  simulation:
+    cloud_number: 1
+    edge_number: 2
+    cluster_name: "ianvs-simulation"
+    kubeedge_version: "1.23.0"
+    sedna_version: "latest"
 ```
 
 ### 6.4 System metrics in reports


### PR DESCRIPTION
/kind documentation

**What this PR does / why we need it:**

Fixes a documentation error in §6.3 "Configuration contract" of the Simulation Sandbox proposal.

The YAML block in §6.3 used `cluster_simulation:` as the block key with `cloud_nodes:`/`edge_nodes:` as leaf keys. However, `BenchmarkingJob._parse_config()` dispatches only on the key `simulation:` (line 107 of benchmarkingjob.py), so `cluster_simulation:` silently produces `self.simulation = None` and `build_simulation_environment()` is never called. Additionally, `cloud_nodes` and `edge_nodes` are not attributes of the `Simulation` class — the correct keys are `cloud_number` and `edge_number`.

This was identified by Yung-Cheng Chen (#881) and verified against the current codebase.

**Which issue(s) this PR fixes:**

Related to #348