### PR TITLE
fix: declare missing runtime dependencies

### DIFF
--- a/examples/llm_simple_qa/requirements.txt
+++ b/examples/llm_simple_qa/requirements.txt
@@ -2,3 +2,5 @@
 transformers >= 4.45.0
 torch >= 2.0.0
 accelerate >= 1.0.0
+mmengine
+opencompass

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ pandas
 tqdm
 matplotlib
 onnx
+colorlog


### PR DESCRIPTION
## Summary

- Added `colorlog` to the project requirements because it is imported by `core/common/log.py`.
- Added `mmengine` and `opencompass` to the `llm_simple_qa` example requirements because they are runtime imports.
- Verified dependency declarations using the dependency validator.

## Validation

```text
python .github/workflows/validator/dependency_validator.py \
  --all \
  --install-mode dry-run \
  --timeout 900 \
  --format markdown