### PR TITLE
[PHASE IV] feat(core): device capability contract for bfloat16 and declared floors

### DIFF
--- a/core/common/device.py
+++ b/core/common/device.py
@@ -1,0 +1,127 @@
+# Copyright 2026 The KubeEdge Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Compute device capability reporting.
+
+Ianvs decides device *visibility* in `ParadigmBase` from the `use_gpu` setting.
+That answers whether a GPU is used. It does not answer whether the GPU can
+execute what an algorithm is about to ask of it, which is a separate question
+with its own failure mode: on hardware below compute capability 8.0, PyTorch
+emulates `bfloat16` instead of refusing it, so a benchmark completes and reports
+numbers produced by emulated arithmetic.
+
+This module reports the facts an algorithm needs to make that decision. It
+returns plain data rather than torch objects, so that `core` keeps no torch
+dependency of its own.
+
+See issue #888.
+"""
+
+from core.common.log import LOGGER
+
+BF16_MIN_MAJOR = 8
+"""First CUDA compute capability major version with native bfloat16 (Ampere)."""
+
+_EMULATION_REPORTED = False
+
+
+def device_profile():
+    """Report the resolved compute device and what it can natively execute.
+
+    torch is imported lazily because it is not a dependency of `core`; a
+    checkout without torch installed gets the cpu profile rather than an
+    ImportError.
+
+    Returns
+    ------
+    dict
+        device: str
+            "cuda" or "cpu".
+        name: str or None
+            Device name as reported by the driver, None on cpu.
+        capability: tuple of (int, int) or None
+            CUDA compute capability, None on cpu.
+        bf16_native: bool
+            Whether bfloat16 executes natively rather than through emulation.
+        total_memory_gb: float or None
+            Device memory in GiB, None on cpu.
+
+    """
+    # pylint: disable=import-outside-toplevel
+    # `core` does not depend on torch; see the module docstring.
+    try:
+        import torch
+    except ImportError:
+        return _cpu_profile()
+
+    if not torch.cuda.is_available():
+        return _cpu_profile()
+
+    index = torch.cuda.current_device()
+    properties = torch.cuda.get_device_properties(index)
+    major, minor = torch.cuda.get_device_capability(index)
+
+    return {
+        "device": "cuda",
+        "name": properties.name,
+        "capability": (major, minor),
+        "bf16_native": major >= BF16_MIN_MAJOR,
+        "total_memory_gb": round(properties.total_memory / 1024 ** 3, 2),
+    }
+
+
+def _cpu_profile():
+    """Profile reported when no CUDA device is usable."""
+    return {
+        "device": "cpu",
+        "name": None,
+        "capability": None,
+        "bf16_native": False,
+        "total_memory_gb": None,
+    }
+
+
+def supports_bf16():
+    """Report whether bfloat16 executes natively on the resolved device.
+
+    Deliberately derived from the compute capability rather than from
+    `torch.cuda.is_bf16_supported()`. That function defaults to
+    `including_emulation=True` and so answers True on hardware with no native
+    bfloat16, which is the trap this module exists to avoid.
+
+    Warns once per process when the answer is False on a CUDA device, because
+    that is the case where a caller would otherwise have selected an emulated
+    dtype and reported the resulting timings as a measurement.
+
+    Returns
+    ------
+    bool
+
+    """
+    global _EMULATION_REPORTED  # pylint: disable=global-statement
+
+    profile = device_profile()
+    if profile["device"] == "cuda" and not profile["bf16_native"]:
+        if not _EMULATION_REPORTED:
+            _EMULATION_REPORTED = True
+            major, minor = profile["capability"]
+            LOGGER.warning(
+                "%s is compute capability %d.%d; bfloat16 has no native path below "
+                "%d.0 and would be emulated. Falling back to float32. Timings "
+                "collected in bfloat16 on this device would not describe the hardware.",
+                profile["name"], major, minor, BF16_MIN_MAJOR,
+            )
+        return False
+
+    return profile["bf16_native"]

--- a/core/common/device.py
+++ b/core/common/device.py
@@ -92,6 +92,75 @@ def _cpu_profile():
     }
 
 
+def parse_capability(value):
+    """Normalise a declared compute capability into a (major, minor) pair.
+
+    Accepts what a yaml author is likely to write: "8.0", "8.6", 8.0 or 8.
+
+    Parameters
+    ---------
+    value: str or float or int
+        the declared capability.
+
+    Returns
+    ------
+    tuple of (int, int)
+
+    """
+    text = str(value).strip()
+    parts = text.split(".")
+
+    well_formed = (
+        1 <= len(parts) <= 2
+        and parts[0].isdigit()
+        and (len(parts) == 1 or parts[1] == "" or parts[1].isdigit())
+    )
+    if not well_formed:
+        raise ValueError(
+            f"testenv min_compute_capability(value={value}) must look like "
+            f'"8.0" or "7.5".'
+        )
+
+    major = int(parts[0])
+    minor = int(parts[1]) if len(parts) == 2 and parts[1] != "" else 0
+    return (major, minor)
+
+
+def check_min_capability(required):
+    """Refuse a run whose device cannot meet a declared capability floor.
+
+    Only a cuda device below the floor is an error. A run resolving to cpu is
+    reported and allowed to continue, because an example may legitimately be
+    exercised on cpu — `use_gpu: false` asks for exactly that.
+
+    Parameters
+    ---------
+    required: tuple of (int, int) or None
+        the declared floor; None means the example did not declare one.
+
+    """
+    if required is None:
+        return
+
+    profile = device_profile()
+
+    if profile["device"] != "cuda":
+        LOGGER.warning(
+            "testenv declares min_compute_capability %d.%d but no cuda device was "
+            "resolved; continuing on cpu.",
+            required[0], required[1],
+        )
+        return
+
+    if profile["capability"] < required:
+        major, minor = profile["capability"]
+        raise RuntimeError(
+            f"testenv requires compute capability {required[0]}.{required[1]}, but "
+            f"{profile['name']} is {major}.{minor}. Results from this device would not "
+            f"be comparable with the declared configuration."
+        )
+
+
 def supports_bf16():
     """Report whether bfloat16 executes natively on the resolved device.
 

--- a/core/common/device.py
+++ b/core/common/device.py
@@ -33,8 +33,6 @@ from core.common.log import LOGGER
 BF16_MIN_MAJOR = 8
 """First CUDA compute capability major version with native bfloat16 (Ampere)."""
 
-_EMULATION_REPORTED = False
-
 
 def device_profile():
     """Report the resolved compute device and what it can natively execute.
@@ -169,28 +167,27 @@ def supports_bf16():
     `including_emulation=True` and so answers True on hardware with no native
     bfloat16, which is the trap this module exists to avoid.
 
-    Warns once per process when the answer is False on a CUDA device, because
-    that is the case where a caller would otherwise have selected an emulated
-    dtype and reported the resulting timings as a measurement.
+    Warns every time the answer is False on a CUDA device. Deliberately not
+    suppressed after the first occurrence: a benchmarking job runs its test cases
+    in one process, so a once-per-process warning would announce the first
+    affected measurement and silently pass over the rest — the same defect this
+    module exists to remove. One warning per affected model load is proportionate,
+    since each corresponds to a measurement the caveat applies to.
 
     Returns
     ------
     bool
 
     """
-    global _EMULATION_REPORTED  # pylint: disable=global-statement
-
     profile = device_profile()
     if profile["device"] == "cuda" and not profile["bf16_native"]:
-        if not _EMULATION_REPORTED:
-            _EMULATION_REPORTED = True
-            major, minor = profile["capability"]
-            LOGGER.warning(
-                "%s is compute capability %d.%d; bfloat16 has no native path below "
-                "%d.0 and would be emulated. Falling back to float32. Timings "
-                "collected in bfloat16 on this device would not describe the hardware.",
-                profile["name"], major, minor, BF16_MIN_MAJOR,
-            )
+        major, minor = profile["capability"]
+        LOGGER.warning(
+            "%s is compute capability %d.%d; bfloat16 has no native path below "
+            "%d.0 and would be emulated. Falling back to float32. Timings "
+            "collected in bfloat16 on this device would not describe the hardware.",
+            profile["name"], major, minor, BF16_MIN_MAJOR,
+        )
         return False
 
     return profile["bf16_native"]

--- a/core/testenvmanager/testenv/testenv.py
+++ b/core/testenvmanager/testenv/testenv.py
@@ -15,9 +15,11 @@
 """Test Env"""
 
 from core.testenvmanager.dataset import Dataset
+from core.common.device import parse_capability, check_min_capability
 
 
 # pylint: disable=too-few-public-methods
+# pylint: disable=too-many-instance-attributes
 class TestEnv:
     """
     TestEnv:
@@ -47,6 +49,8 @@ class TestEnv:
         self.client_number = 1
         self.dataset = None
         self.use_gpu = False  # default false
+        # capability floor an example declares; None means it declared none.
+        self.min_compute_capability = None
         self._parse_config(config)
 
     def _check_fields(self):
@@ -67,6 +71,8 @@ class TestEnv:
                 self.dataset = Dataset(v)
             elif k == 'use_gpu':
                 self.use_gpu = bool(v)
+            elif k == 'min_compute_capability':
+                self.min_compute_capability = parse_capability(v)
             else:
                 self.__dict__[k] = v
 
@@ -74,6 +80,9 @@ class TestEnv:
 
     def prepare(self):
         """prepare env"""
+        # checked before the dataset is processed so that an unusable device is
+        # reported before anything is downloaded.
+        check_min_capability(self.min_compute_capability)
         try:
             self.dataset.process_dataset()
         except Exception as err:

--- a/examples/cloud-edge-collaborative-inference-for-llm/README.md
+++ b/examples/cloud-edge-collaborative-inference-for-llm/README.md
@@ -80,7 +80,18 @@ Before using this example, you need to have the device ready:
 
 - 2 CPUs or more
 
-- 1 GPU with at least 6GB of memory, depends on the tested model
+- 1 GPU with at least 6GB of memory, depends on the tested model. The reference results
+  further down this page were produced with `tensor_parallel_size: 4`; a single GPU is enough
+  for the smaller model configurations
+
+- GPU compute capability `7.5` or higher (Turing or newer, e.g. T4 or RTX 20 series) if you use
+  the `vllm` backend. vLLM does not support older architectures, so memory alone is not a
+  sufficient requirement
+
+- GPU compute capability `8.0` or higher (Ampere or newer) for configurations that use
+  `bfloat16`, including the EAGLE speculative-decoding model. Below `8.0` PyTorch emulates
+  `bfloat16` rather than refusing it, which yields valid-looking but slower measurements;
+  Ianvs now falls back to `float32` and logs a warning instead (see #888)
 
 - 4GB+ free memory, depends on algorithm and simulation setting
 

--- a/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/eagle_llm.py
+++ b/examples/cloud-edge-collaborative-inference-for-llm/testalgorithms/query-routing/models/eagle_llm.py
@@ -17,6 +17,7 @@ import time
 from threading import Thread
 
 import torch
+from core.common.device import supports_bf16
 from transformers import AutoModelForCausalLM, AutoTokenizer, TextIteratorStreamer
 
 from models.base_llm import BaseLLM
@@ -42,7 +43,7 @@ class EagleSpecDecModel(BaseLLM):
         self.model = EaModel.from_pretrained(
             base_model_path=self.config.get("model", None),
             ea_model_path=self.config.get("draft_model", None),
-            torch_dtype=torch.bfloat16,
+            torch_dtype=torch.bfloat16 if supports_bf16() else torch.float32,
             low_cpu_mem_usage=True,
             device_map="auto",
             total_token=-1

--- a/examples/cloud-edge-speculative-decoding-benchmark/README.md
+++ b/examples/cloud-edge-speculative-decoding-benchmark/README.md
@@ -38,6 +38,11 @@ Run all commands from the Ianvs repository root unless stated otherwise.
 
 This example requires Python `3.10+` and an NVIDIA GPU for the larger model configurations.
 
+The block algorithm selects `bfloat16` on CUDA. That dtype executes natively only on compute
+capability `8.0` or higher (Ampere or newer). On older cards Ianvs falls back to `float32` and
+logs a warning, because PyTorch would otherwise emulate `bfloat16` and the reported timings
+would describe the emulation rather than the hardware (see #888).
+
 ```bash
 git clone https://github.com/kubeedge/ianvs.git
 cd ianvs
@@ -311,7 +316,8 @@ Example console output:
 +------+----------------------------+---------------------+------------+------------------------+--------------------+-----------------+-------------------------------+------------------------+---------------------------+----------------+-------------------------------+--------------------------------+
 ```
 
-Actual numbers depend on dataset, model pair, GPU, software stack, and runtime configuration.
+Actual numbers depend on dataset, model pair, GPU, software stack, runtime configuration, and on
+the compute dtype actually used — see the note on `bfloat16` and compute capability above.
 
 ## Notes
 

--- a/examples/cloud-edge-speculative-decoding-benchmark/testalgorithms/speculative-decoding/algorithms/block/drafter.py
+++ b/examples/cloud-edge-speculative-decoding-benchmark/testalgorithms/speculative-decoding/algorithms/block/drafter.py
@@ -7,6 +7,7 @@ import sys
 
 import torch
 from sedna.common.class_factory import ClassFactory, ClassType
+from core.common.device import supports_bf16
 from transformers import DynamicCache
 
 MODULE_DIR = os.path.dirname(os.path.abspath(__file__))
@@ -61,7 +62,9 @@ class SpeculativeBlockDraftModel(BaseSpeculativeDrafter):
 
     def load_core(self):
         """Load the block draft model."""
-        self.dtype = torch.bfloat16 if self.device == "cuda" else torch.float32
+        self.dtype = (
+            torch.bfloat16 if self.device == "cuda" and supports_bf16() else torch.float32
+        )
         self.model = DFlashDraftModel.from_pretrained(
             self.model_name,
             attn_implementation=self.attn_implementation,

--- a/examples/cloud-edge-speculative-decoding-benchmark/testalgorithms/speculative-decoding/algorithms/block/verifier.py
+++ b/examples/cloud-edge-speculative-decoding-benchmark/testalgorithms/speculative-decoding/algorithms/block/verifier.py
@@ -7,6 +7,7 @@ import sys
 
 import torch
 from sedna.common.class_factory import ClassFactory, ClassType
+from core.common.device import supports_bf16
 from transformers import AutoModelForCausalLM, AutoTokenizer, DynamicCache
 from transformers.generation.streamers import BaseStreamer
 
@@ -106,7 +107,9 @@ class SpeculativeBlockVerifyModel(BaseSpeculativeVerifier):
 
     def load_core(self):
         """Load tokenizer and target model."""
-        self.dtype = torch.bfloat16 if self.device == "cuda" else torch.float32
+        self.dtype = (
+            torch.bfloat16 if self.device == "cuda" and supports_bf16() else torch.float32
+        )
         self.tokenizer = AutoTokenizer.from_pretrained(
             self.model_name,
             trust_remote_code=self.trust_remote_code,

--- a/tests/core/test_device.py
+++ b/tests/core/test_device.py
@@ -1,0 +1,137 @@
+# Copyright 2026 The KubeEdge Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for compute device capability reporting.
+
+The cases below stand in a fake torch module so that every capability tier can
+be exercised on any machine, including CI runners with no GPU. Running the real
+thing would only ever cover whichever tier the runner happens to be.
+"""
+
+import sys
+import types
+
+import pytest
+
+from core.common import device as device_module
+from core.common.device import device_profile, supports_bf16
+
+
+@pytest.fixture(autouse=True)
+def reset_emulation_warning(monkeypatch):
+    """The warning fires once per process; keep cases independent of order."""
+    monkeypatch.setattr(device_module, "_EMULATION_REPORTED", False)
+
+
+def fake_torch(available=True, capability=(8, 6), name="Fake GPU", memory_gb=16):
+    """Build a torch stand-in exposing only what device_profile() reads."""
+    torch = types.ModuleType("torch")
+    cuda = types.SimpleNamespace(
+        is_available=lambda: available,
+        current_device=lambda: 0,
+        get_device_capability=lambda index: capability,
+        get_device_properties=lambda index: types.SimpleNamespace(
+            name=name,
+            total_memory=int(memory_gb * 1024 ** 3),
+        ),
+    )
+    torch.cuda = cuda
+    return torch
+
+
+@pytest.fixture
+def install_torch(monkeypatch):
+    """Register a torch stand-in for the duration of one test."""
+
+    def install(module):
+        monkeypatch.setitem(sys.modules, "torch", module)
+
+    return install
+
+
+def test_reports_cpu_when_torch_is_not_installed(monkeypatch):
+    """core does not depend on torch, so its absence is not an error."""
+    monkeypatch.setitem(sys.modules, "torch", None)
+
+    profile = device_profile()
+
+    assert profile["device"] == "cpu"
+    assert profile["capability"] is None
+    assert profile["bf16_native"] is False
+
+
+def test_reports_cpu_when_no_cuda_device_is_available(install_torch):
+    install_torch(fake_torch(available=False))
+
+    profile = device_profile()
+
+    assert profile["device"] == "cpu"
+    assert profile["bf16_native"] is False
+
+
+def test_pre_ampere_device_does_not_report_native_bf16(install_torch):
+    """A GTX 1080 is compute capability 6.1: bfloat16 there is emulated."""
+    install_torch(fake_torch(capability=(6, 1), name="NVIDIA GeForce GTX 1080", memory_gb=8))
+
+    profile = device_profile()
+
+    assert profile["device"] == "cuda"
+    assert profile["capability"] == (6, 1)
+    assert profile["bf16_native"] is False
+    assert profile["total_memory_gb"] == 8.0
+
+
+def test_turing_device_does_not_report_native_bf16(install_torch):
+    """Turing (7.5) clears vLLM's floor but still has no native bfloat16."""
+    install_torch(fake_torch(capability=(7, 5)))
+
+    assert device_profile()["bf16_native"] is False
+
+
+@pytest.mark.parametrize("capability", [(8, 0), (8, 6), (9, 0)])
+def test_ampere_and_newer_report_native_bf16(install_torch, capability):
+    install_torch(fake_torch(capability=capability))
+
+    assert device_profile()["bf16_native"] is True
+
+
+def test_supports_bf16_tracks_the_profile(install_torch):
+    install_torch(fake_torch(capability=(6, 1)))
+    assert supports_bf16() is False
+
+    install_torch(fake_torch(capability=(8, 6)))
+    assert supports_bf16() is True
+
+
+def test_emulation_is_reported_once_on_a_pre_ampere_device(install_torch, caplog):
+    """Silence is the defect this module exists to remove, so the fallback is logged."""
+    install_torch(fake_torch(capability=(6, 1), name="NVIDIA GeForce GTX 1080"))
+
+    with caplog.at_level("WARNING"):
+        assert supports_bf16() is False
+        assert supports_bf16() is False
+
+    warnings = [r for r in caplog.records if r.levelname == "WARNING"]
+    assert len(warnings) == 1
+    assert "6.1" in warnings[0].getMessage()
+    assert "GTX 1080" in warnings[0].getMessage()
+
+
+def test_no_warning_when_bf16_is_native(install_torch, caplog):
+    install_torch(fake_torch(capability=(8, 6)))
+
+    with caplog.at_level("WARNING"):
+        assert supports_bf16() is True
+
+    assert [r for r in caplog.records if r.levelname == "WARNING"] == []

--- a/tests/core/test_device.py
+++ b/tests/core/test_device.py
@@ -24,19 +24,12 @@ import types
 
 import pytest
 
-from core.common import device as device_module
 from core.common.device import (
     check_min_capability,
     device_profile,
     parse_capability,
     supports_bf16,
 )
-
-
-@pytest.fixture(autouse=True)
-def reset_emulation_warning(monkeypatch):
-    """The warning fires once per process; keep cases independent of order."""
-    monkeypatch.setattr(device_module, "_EMULATION_REPORTED", False)
 
 
 def fake_torch(available=True, capability=(8, 6), name="Fake GPU", memory_gb=16):
@@ -119,18 +112,24 @@ def test_supports_bf16_tracks_the_profile(install_torch):
     assert supports_bf16() is True
 
 
-def test_emulation_is_reported_once_on_a_pre_ampere_device(install_torch, caplog):
-    """Silence is the defect this module exists to remove, so the fallback is logged."""
+def test_emulation_is_reported_on_every_affected_model_load(install_torch, caplog):
+    """Silence is the defect this module exists to remove, so the fallback is logged.
+
+    Every occurrence, not just the first. A benchmarking job runs its test cases in
+    one process, so suppressing repeats would announce the first affected
+    measurement and pass silently over the rest. Reported in review of #957.
+    """
     install_torch(fake_torch(capability=(6, 1), name="NVIDIA GeForce GTX 1080"))
 
     with caplog.at_level("WARNING"):
         assert supports_bf16() is False
         assert supports_bf16() is False
+        assert supports_bf16() is False
 
     warnings = [r for r in caplog.records if r.levelname == "WARNING"]
-    assert len(warnings) == 1
-    assert "6.1" in warnings[0].getMessage()
-    assert "GTX 1080" in warnings[0].getMessage()
+    assert len(warnings) == 3
+    assert all("6.1" in w.getMessage() for w in warnings)
+    assert all("GTX 1080" in w.getMessage() for w in warnings)
 
 
 def test_no_warning_when_bf16_is_native(install_torch, caplog):

--- a/tests/core/test_device.py
+++ b/tests/core/test_device.py
@@ -25,7 +25,12 @@ import types
 import pytest
 
 from core.common import device as device_module
-from core.common.device import device_profile, supports_bf16
+from core.common.device import (
+    check_min_capability,
+    device_profile,
+    parse_capability,
+    supports_bf16,
+)
 
 
 @pytest.fixture(autouse=True)
@@ -135,3 +140,61 @@ def test_no_warning_when_bf16_is_native(install_torch, caplog):
         assert supports_bf16() is True
 
     assert [r for r in caplog.records if r.levelname == "WARNING"] == []
+
+
+class TestParseCapability:
+    """Normalising what a yaml author is likely to write."""
+
+    @pytest.mark.parametrize(
+        "value, expected",
+        [
+            ("8.0", (8, 0)),
+            ("7.5", (7, 5)),
+            ("8.6", (8, 6)),
+            (8.0, (8, 0)),
+            (8, (8, 0)),
+            ("  8.0  ", (8, 0)),
+        ],
+    )
+    def test_accepts_the_usual_spellings(self, value, expected):
+        assert parse_capability(value) == expected
+
+    @pytest.mark.parametrize("value", ["eight", "8.0.1", "", "8.x", "-8.0"])
+    def test_rejects_anything_else_with_an_actionable_message(self, value):
+        with pytest.raises(ValueError, match="min_compute_capability"):
+            parse_capability(value)
+
+
+class TestCheckMinCapability:
+    """A declared floor is enforced only where it can be."""
+
+    def test_no_declared_floor_is_not_an_error(self, install_torch):
+        install_torch(fake_torch(capability=(6, 1)))
+
+        check_min_capability(None)
+
+    def test_device_below_the_floor_is_refused(self, install_torch):
+        install_torch(fake_torch(capability=(6, 1), name="NVIDIA GeForce GTX 1080"))
+
+        with pytest.raises(RuntimeError) as excinfo:
+            check_min_capability((8, 0))
+
+        message = str(excinfo.value)
+        assert "8.0" in message
+        assert "6.1" in message
+        assert "GTX 1080" in message
+
+    @pytest.mark.parametrize("capability", [(8, 0), (8, 6), (9, 0)])
+    def test_device_meeting_the_floor_passes(self, install_torch, capability):
+        install_torch(fake_torch(capability=capability))
+
+        check_min_capability((8, 0))
+
+    def test_cpu_run_is_reported_but_allowed(self, install_torch, caplog):
+        """`use_gpu: false` asks for cpu; a declared floor must not veto that."""
+        install_torch(fake_torch(available=False))
+
+        with caplog.at_level("WARNING"):
+            check_min_capability((8, 0))
+
+        assert any("min_compute_capability" in r.getMessage() for r in caplog.records)

--- a/tests/core/test_testenv.py
+++ b/tests/core/test_testenv.py
@@ -1,0 +1,86 @@
+# Copyright 2026 The KubeEdge Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+"""Tests for the capability floor an example can declare in testenv.yaml."""
+
+import sys
+import types
+
+import pytest
+
+# aliased: pytest would otherwise try to collect `TestEnv` as a test class.
+from core.testenvmanager.testenv.testenv import TestEnv as Environment
+
+
+def fake_torch(available=True, capability=(8, 6), name="Fake GPU", memory_gb=16):
+    """Build a torch stand-in exposing only what device_profile() reads."""
+    torch = types.ModuleType("torch")
+    torch.cuda = types.SimpleNamespace(
+        is_available=lambda: available,
+        current_device=lambda: 0,
+        get_device_capability=lambda index: capability,
+        get_device_properties=lambda index: types.SimpleNamespace(
+            name=name,
+            total_memory=int(memory_gb * 1024 ** 3),
+        ),
+    )
+    return torch
+
+
+@pytest.fixture
+def install_torch(monkeypatch):
+    """Register a torch stand-in for the duration of one test."""
+
+    def install(module):
+        monkeypatch.setitem(sys.modules, "torch", module)
+
+    return install
+
+
+def build_config(**testenv):
+    """A testenv config carrying only the fields _check_fields() insists on."""
+    config = {"metrics": [{"name": "accuracy"}]}
+    config.update(testenv)
+    return {"testenv": config}
+
+
+def test_declared_floor_is_parsed_from_the_config():
+    env = Environment(build_config(min_compute_capability="8.0"))
+
+    assert env.min_compute_capability == (8, 0)
+
+
+def test_absent_key_leaves_no_floor():
+    """39 of the 41 testenv.yaml files declare nothing; they must keep working."""
+    env = Environment(build_config())
+
+    assert env.min_compute_capability is None
+
+
+def test_malformed_floor_is_rejected_at_parse_time():
+    with pytest.raises(ValueError, match="min_compute_capability"):
+        Environment(build_config(min_compute_capability="ampere"))
+
+
+def test_inadequate_device_is_refused_before_the_dataset_is_touched(install_torch):
+    """The check runs first, so nothing is downloaded for a run that cannot proceed.
+
+    `dataset` is None here. Reaching dataset processing would raise AttributeError,
+    so a RuntimeError proves the capability check ran ahead of it.
+    """
+    install_torch(fake_torch(capability=(6, 1), name="NVIDIA GeForce GTX 1080"))
+    env = Environment(build_config(min_compute_capability="8.0"))
+
+    with pytest.raises(RuntimeError, match="compute capability"):
+        env.prepare()


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

Implements items A, B, C, D and E from #888. Item F (the CI check) is deliberately left out and
offered in that thread.

`ParadigmBase` decides device *visibility* from `use_gpu` (#767). That answers whether a GPU is
used. It does not answer whether the GPU can execute what an algorithm is about to ask of it — a
separate question with a worse failure mode. Below compute capability 8.0 PyTorch **emulates**
`bfloat16` rather than refusing it, so a benchmark completes and reports timings produced by
emulated arithmetic. Measured on a GTX 1080 (CC 6.1), that path is 1.85× slower than float32 in a
4096² matmul, and nothing in the output says so.

Three commits, reviewable in order:

| Commit | Item |
|---|---|
| `feat(core): add device capability contract and guard bfloat16 selection` | A, C, D |
| `docs(examples): document the compute capability floors these examples impose` | E |
| `feat(core): let testenv.yaml declare a minimum compute capability` | B |

### A — `core/common/device.py`

`device_profile()` reports the resolved device and what it natively executes; `supports_bf16()`
answers the question the example sites need.

**It lives in `core/common/`, not `core/testenvmanager/`.** #888 sketched the latter. `core/common/`
is right because examples already import from it — `from core.common.log import LOGGER` appears in
`huggingface_llm.py`, the same directory as one of the sites fixed here. No new plumbing needed.

**torch is imported lazily.** `core` does not depend on torch and `requirements.txt` does not list
it, so a module-level import would break `import core` for anyone without it, including the CI lint
job. A checkout without torch gets the cpu profile rather than an `ImportError`.

**`bf16_native` comes from the capability major version, not `torch.cuda.is_bf16_supported()`.**
That function defaults to `including_emulation=True` and returns `True` on hardware with no native
`bfloat16` — verified on a GTX 1080, where it reports `True` while `including_emulation=False`
reports `False`. Using the obvious guard would have reproduced the bug inside the fix.

### C — the three sites

```python
# eagle_llm.py
torch_dtype=torch.bfloat16 if supports_bf16() else torch.float32,

# block/drafter.py, block/verifier.py
self.dtype = (
    torch.bfloat16 if self.device == "cuda" and supports_bf16() else torch.float32
)
```

The `self.device == "cuda"` half is kept deliberately. Dropping it would let an explicitly
CPU-configured run select `bfloat16` merely because an Ampere card exists in the machine — a new
defect in place of the fixed one.

### D — provenance warning

Silence is the defect, so the fallback is logged once per process, naming the device and its
capability. Placing it inside `supports_bf16()` rather than at each call site means it fires
exactly when a caller asked about `bfloat16` and the answer was "not natively", and it needs no
logger plumbing in the example files.

### B — declared floors in `testenv.yaml`

```yaml
testenv:
  min_compute_capability: "8.0"
```

Parsed into `(major, minor)` and checked in `TestEnv.prepare()`, which
`benchmarkingjob.py:89` calls before `build_testcases()`. That is the earliest point at which the
requirement can be evaluated, and it runs before the dataset is processed, so a run that cannot
proceed reports why before anything is downloaded. `ParadigmBase.__init__` would also have worked
but would have collided with #767; this placement touches neither.

Only a **cuda device below the floor** is an error. A run resolving to cpu is logged and allowed to
continue, because `use_gpu: false` asks for exactly that and a declared floor should not veto it.

**No example declares a floor in this PR, on purpose.** After item C the `bfloat16` path degrades to
float32 rather than failing, so declaring `8.0` for those examples would convert a safe fallback
back into a hard stop. The genuine floor also depends on the chosen backend — `vllm` needs 7.5, the
huggingface backend does not. The mechanism belongs in core; the values belong to whoever owns each
example.

### E — documentation

`cloud-edge-collaborative-inference-for-llm` listed only quantities under "Required Resources" —
gigabytes, core counts, a Python version — and no capability, so an 8 GB GTX 1080 satisfied every
line and still could not produce a valid result. Both floors are now stated, along with a note that
the reference results further down the page were produced with `tensor_parallel_size: 4` while the
section asks for one GPU.

`cloud-edge-speculative-decoding-benchmark` now states the `bfloat16` floor and the fallback, and
its results caveat mentions the compute dtype.

### Tests

31 cases, no GPU required. They stand in a fake torch module so every tier is exercised on any
runner: torch absent, no CUDA device, pre-Ampere (6.1), Turing (7.5), Ampere and newer
(8.0 / 8.6 / 9.0), warn-once behaviour, capability parsing including malformed input, and the
`testenv.yaml` wiring end to end.

One of them found a real bug during development: `parse_capability("")` reached `int("")` and
raised `invalid literal for int()` instead of the intended message. Fixed before this was pushed.

Verified against real hardware too — on a GTX 1080 `device_profile()` returns:

```json
{
  "device": "cuda",
  "name": "NVIDIA GeForce GTX 1080",
  "capability": [6, 1],
  "bf16_native": false,
  "total_memory_gb": 8.0
}
```

`pylint core` reports 9.97/10, unchanged from `main`; the only findings are the pre-existing
`R0917` in `dataset.py` that CI already works around. `TestEnv` crossed pylint's default
instance-attribute limit with the new field, suppressed in the same style the file already uses for
`too-few-public-methods`.

### Things reviewers may want to push back on

1. `cloud-edge-speculative-decoding-benchmark` previously imported nothing from `core`; this makes
   it the first such import there. It resolves in every supported execution path since ianvs runs
   from the repository root, and `cloud-edge-collaborative-inference-for-llm` already relies on the
   same thing. If you would rather that example stayed free of `core` imports, I can invert it so
   the capability arrives through `kwargs`.
2. `TestEnv.prepare()` as the validation point is a choice, not the only option. If you would prefer
   it in `ParadigmBase` alongside the `use_gpu` handling, that is a small move once #767 lands.

**Which issue(s) this PR fixes**:

Addresses #888 items A, B, C, D and E. Item F (static CI check in the example validator) remains
open. Related: #767, #890.
