### PR TITLE
Fix algorithm field validation

### DIFF
--- a/core/testcasecontroller/algorithm/algorithm.py
+++ b/core/testcasecontroller/algorithm/algorithm.py
@@ -130,10 +130,10 @@ class Algorithm:
         return None
 
     def _check_fields(self):
-        if not self.name and not isinstance(self.name, str):
+        if not self.name or not isinstance(self.name, str):
             raise ValueError(f"algorithm name({self.name}) must be provided and be string type.")
 
-        if not self.paradigm_type and not isinstance(self.paradigm_type, str):
+        if not self.paradigm_type or not isinstance(self.paradigm_type, str):
             raise ValueError(
                 f"algorithm paradigm({self.paradigm_type}) must be provided and be string type.")
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+testpaths = tests
+pythonpath = .

--- a/tests/core/testcasecontroller/algorithm/test_algorithm.py
+++ b/tests/core/testcasecontroller/algorithm/test_algorithm.py
@@ -1,0 +1,22 @@
+import pytest
+
+from core.testcasecontroller.algorithm.algorithm import Algorithm
+
+
+def make_config(name="test", paradigm_type="singletasklearning"):
+    return {
+        "algorithm": {
+            "name": name,
+            "paradigm_type": paradigm_type,
+        }
+    }
+
+
+def test_algorithm_rejects_non_string_name():
+    with pytest.raises(ValueError, match="algorithm name"):
+        Algorithm("test", make_config(name=123))
+
+
+def test_algorithm_rejects_non_string_paradigm_type():
+    with pytest.raises(ValueError, match="algorithm paradigm"):
+        Algorithm("test", make_config(paradigm_type=123))


### PR DESCRIPTION
## Summary

- Fix algorithm name validation to reject missing or non-string values.
- Fix paradigm type validation to reject missing or non-string values.
- Add regression tests for invalid field types.

## Testing

- `pytest -q`
- Result: 2 passed