### PR TITLE
[PHASE IV] fix(llm_simple_qa): pass do_sample explicitly so the benchmark is reproducible

### DIFF
--- a/examples/llm_simple_qa/testalgorithms/gen/basemodel.py
+++ b/examples/llm_simple_qa/testalgorithms/gen/basemodel.py
@@ -89,9 +89,13 @@ class BaseModel:
         )
         model_inputs = self.tokenizer([text], return_tensors="pt").to(device)
         
+        # do_sample is passed explicitly: without it the value comes from the
+        # model's own generation_config.json, which enables sampling for chat
+        # models and makes the benchmark score vary between identical runs.
         generated_ids = self.model.generate(
             model_inputs.input_ids,
-            max_new_tokens=512
+            max_new_tokens=512,
+            do_sample=False
         )
         generated_ids = [
             output_ids[len(input_ids):] for input_ids, output_ids in zip(model_inputs.input_ids, generated_ids)


### PR DESCRIPTION
**What type of PR is this?**

/kind bug

**What this PR does / why we need it**:

`examples/llm_simple_qa` scores differently on every run. Four end-to-end runs of unchanged code and
configuration produced 0.6, 0.7, 0.8 and 0.9, reported in #988.

The cause is one missing argument. `basemodel.py` calls

```python
generated_ids = self.model.generate(
    model_inputs.input_ids,
    max_new_tokens=512
)
```

Because `do_sample` is not passed, its value comes from the model's own `generation_config.json`.
For `Qwen/Qwen2.5-0.5B-Instruct` that file sets `do_sample=True, temperature=0.7, top_p=0.8,
top_k=20`. The example never asked for stochastic decoding; it inherits chat defaults from a
third-party model card that can also change without any commit here.

This passes `do_sample=False` explicitly. Greedy decoding is the usual choice for evaluation, and it
removes the dependency on an external file for a property the benchmark depends on.

### Verification

On a GTX 1080, `workspace/benchmarkingjob/rank/all_rank.csv` after four consecutive runs of the
unchanged job:

**Before** (from #988):

```
0.9   2026-08-28 20:31:40
0.8   2026-08-28 20:41:33
0.7   2026-08-28 20:34:55
0.6   2026-08-28 20:25:06
```

**After**, workspace cleared first, four runs:

```
0.6   2026-08-28 20:52:55
0.6   2026-08-28 20:55:01
0.6   2026-08-28 20:57:07
0.6   2026-08-28 21:00:11
```

Four distinct run ids and timestamps, one score. `transformers` emits no warning about the now-unused
`temperature` and `top_p` from the generation config.

### Scope

Only `llm_simple_qa` is changed, deliberately.

Nine other `generate()` calls exist under `examples/`. The closest relatives —
`government/singletask_learning_bench` (objective and subjective) and
`smart_coding_learning_bench` (comment and issue) — pass `temperature=0.1, top_p=0.9` explicitly.
That is an author expressing intent to sample, and silently converting it to greedy decoding would
be a different change requiring a different conversation. They also load models from hardcoded local
paths such as `/home/icyfeather/models/`, so they cannot run for anyone else today; determinism is
not their first problem.

`llm_simple_qa` is the only one that passes no decoding arguments at all and therefore inherits the
behaviour silently.

### Not addressed here

#988 also raises three related points that are deliberately left out of this PR:

- A configurable seed in `testenv.yaml` for examples that genuinely intend to sample. That changes
  the config schema and is worth designing with maintainers.
- Recording in the report whether decoding was deterministic. That touches the results pipeline.
- The ten-row test set giving a metric resolution of 0.1, which is a separate discussion.

**Which issue(s) this PR fixes**:

Fixes #988
